### PR TITLE
CI: Remove obsolete jobs and fix config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -244,15 +244,15 @@ jobs:
           command: |
             # Setting CIRCLE_TAG because we do not tag the release ourselves.
             source /tmp/workspace/release-version.source
-            if test ${CIRCLE_NODE_INDEX:-0} == 0 ;then export GOOS=linux GOARCH=amd64   && export OUTPUT=build/tendermint_${GOOS}_${GOARCH} && make build && python -u scripts/release_management/zip-file.py ;fi
-            if test ${CIRCLE_NODE_INDEX:-0} == 1 ;then export GOOS=darwin GOARCH=amd64  && export OUTPUT=build/tendermint_${GOOS}_${GOARCH} && make build && python -u scripts/release_management/zip-file.py ;fi
-            if test ${CIRCLE_NODE_INDEX:-0} == 2 ;then export GOOS=windows GOARCH=amd64 && export OUTPUT=build/tendermint_${GOOS}_${GOARCH} && make build && python -u scripts/release_management/zip-file.py ;fi
-            if test ${CIRCLE_NODE_INDEX:-0} == 3 ;then export GOOS=linux GOARCH=arm     && export OUTPUT=build/tendermint_${GOOS}_${GOARCH} && make build && python -u scripts/release_management/zip-file.py ;fi
+            if test ${CIRCLE_NODE_INDEX:-0} == 0 ;then export GOOS=linux GOARCH=amd64   && export OUTPUT=build/lazyledger-core_${GOOS}_${GOARCH} && make build && python -u scripts/release_management/zip-file.py ;fi
+            if test ${CIRCLE_NODE_INDEX:-0} == 1 ;then export GOOS=darwin GOARCH=amd64  && export OUTPUT=build/lazyledger-core_${GOOS}_${GOARCH} && make build && python -u scripts/release_management/zip-file.py ;fi
+            if test ${CIRCLE_NODE_INDEX:-0} == 2 ;then export GOOS=windows GOARCH=amd64 && export OUTPUT=build/lazyledger-core_${GOOS}_${GOARCH} && make build && python -u scripts/release_management/zip-file.py ;fi
+            if test ${CIRCLE_NODE_INDEX:-0} == 3 ;then export GOOS=linux GOARCH=arm     && export OUTPUT=build/lazyledger-core_${GOOS}_${GOARCH} && make build && python -u scripts/release_management/zip-file.py ;fi
       - persist_to_workspace:
           root: build
           paths:
             - "*.zip"
-            - "lazyledger_linux_amd64"
+            - "lazyledger-core_linux_amd64"
 
   release_artifacts:
     executor: golang

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ executors:
   golang:
     docker:
       - image: tendermintdev/docker-tendermint-build
-    working_directory: /go/src/github.com/tendermint/tendermint
+    working_directory: /go/src/github.com/lazyledger/lazyledger-core
     environment:
       GOBIN: /tmp/bin
   release:
@@ -118,7 +118,7 @@ jobs:
             export VERSION="$(git describe --tags --long | sed 's/v\(.*\)/\1/')"
             export GO111MODULE=on
             mkdir -p /tmp/logs /tmp/workspace/profiles
-            for pkg in $(go list github.com/tendermint/tendermint/... | circleci tests split --split-by=timings); do
+            for pkg in $(go list github.com/lazyledger/lazyledger-core/... | circleci tests split --split-by=timings); do
               id=$(basename "$pkg")
               go test -v -timeout 5m -mod=readonly -race -coverprofile=/tmp/workspace/profiles/$id.out -covermode=atomic "$pkg" | tee "/tmp/logs/$id-$RANDOM.log"
             done
@@ -130,7 +130,7 @@ jobs:
           path: /tmp/logs
 
   localnet:
-    working_directory: /home/circleci/.go_workspace/src/github.com/tendermint/tendermint
+    working_directory: /home/circleci/.go_workspace/src/github.com/lazyledger/lazyledger-core
     machine:
       image: circleci/classic:latest
     environment:
@@ -145,7 +145,7 @@ jobs:
           name: run localnet and exit on failure
           command: |
             set -x
-            docker run --rm -v "$PWD":/go/src/github.com/tendermint/tendermint -w /go/src/github.com/tendermint/tendermint golang make build-linux
+            docker run --rm -v "$PWD":/go/src/github.com/lazyledger/lazyledger-core -w /go/src/github.com/lazyledger/lazyledger-core golang make build-linux
             make localnet-start &
             ./scripts/localnet-blocks-test.sh 40 5 10 localhost
 
@@ -161,8 +161,8 @@ jobs:
         default: 4
     steps:
       - checkout
-      - run: mkdir -p $GOPATH/src/github.com/tendermint
-      - run: ln -sf /home/circleci/project $GOPATH/src/github.com/tendermint/tendermint
+      - run: mkdir -p $GOPATH/src/github.com/lazyledger
+      - run: ln -sf /home/circleci/project $GOPATH/src/github.com/lazyledger/lazyledger-core
       - run: bash test/p2p/circleci.sh << parameters.ipv >>
       - store_artifacts:
           path: /home/circleci/project/test/p2p/logs
@@ -191,17 +191,6 @@ jobs:
       - run:
           name: upload
           command: bash .circleci/codecov.sh -f coverage.txt
-
-  deploy_docs:
-    executor: docs
-    steps:
-      - checkout
-      - run:
-          name: "Build docs"
-          command: make build-docs
-      - run:
-          name: "Sync to S3"
-          command: make sync-docs
 
   prepare_build:
     executor: golang
@@ -263,7 +252,7 @@ jobs:
           root: build
           paths:
             - "*.zip"
-            - "tendermint_linux_amd64"
+            - "lazyledger_linux_amd64"
 
   release_artifacts:
     executor: golang
@@ -297,98 +286,10 @@ jobs:
             python -u scripts/release_management/github-upload.py --file "/tmp/workspace/SHA256SUMS" --id "${RELEASE_ID}"
             python -u scripts/release_management/github-publish.py --id "${RELEASE_ID}"
 
-  release_docker:
-    machine:
-      image: ubuntu-1604:201903-01
-    steps:
-      - checkout
-      - attach_workspace:
-          at: /tmp/workspace
-      - run:
-          name: "Deploy to Docker Hub"
-          command: |
-            # Setting CIRCLE_TAG because we do not tag the release ourselves.
-            source /tmp/workspace/release-version.source
-            cp /tmp/workspace/tendermint_linux_amd64 DOCKER/tendermint
-            docker build --label="tendermint" --tag="tendermint/tendermint:${CIRCLE_TAG}" --tag="tendermint/tendermint:latest" "DOCKER"
-            docker login -u "${DOCKERHUB_USER}" --password-stdin \<<< "${DOCKERHUB_PASS}"
-            docker push "tendermint/tendermint"
-            docker logout
-
-  reproducible_builds:
-    executor: golang
-    steps:
-      - attach_workspace:
-          at: /tmp/workspace
-      - checkout
-      - setup_remote_docker:
-          docker_layer_caching: true
-      - run:
-          name: Build tendermint
-          no_output_timeout: 20m
-          command: |
-            sudo apt-get update
-            sudo apt-get install -y ruby
-            bash -x ./scripts/gitian-build.sh all
-            for os in darwin linux windows; do
-              cp gitian-build-${os}/result/tendermint-${os}-res.yml .
-              cp gitian-build-${os}/build/out/tendermint-*.tar.gz .
-              rm -rf gitian-build-${os}/
-            done
-      - store_artifacts:
-          path: /go/src/github.com/tendermint/tendermint/tendermint-darwin-res.yml
-      - store_artifacts:
-          path: /go/src/github.com/tendermint/tendermint/tendermint-linux-res.yml
-      - store_artifacts:
-          path: /go/src/github.com/tendermint/tendermint/tendermint-windows-res.yml
-      - store_artifacts:
-          path: /go/src/github.com/tendermint/tendermint/tendermint-*.tar.gz
-
-  # # Test RPC implementation against the swagger documented specs
-  # contract_tests:
-  #   working_directory: /home/circleci/.go_workspace/src/github.com/tendermint/tendermint
-  #   machine:
-  #     image: circleci/classic:latest
-  #   environment:
-  #     GOBIN: /home/circleci/.go_workspace/bin
-  #     GOPATH: /home/circleci/.go_workspace/
-  #     GOOS: linux
-  #     GOARCH: amd64
-  #   parallelism: 1
-  #   steps:
-  #     - checkout
-  #     - run:
-  #         name: Test RPC endpoints against swagger documentation
-  #         command: |
-  #           set -x
-  #           export PATH=~/.local/bin:$PATH
-  #           # install node and dredd
-  #           ./scripts/get_nodejs.sh
-  #           # build the binaries with a proper version of Go
-  #           docker run --rm -v "$PWD":/go/src/github.com/tendermint/tendermint -w /go/src/github.com/tendermint/tendermint golang make build-linux build-contract-tests-hooks
-  #           # This docker image works with go 1.7, we can install here the hook handler that contract-tests is going to use
-  #           go get github.com/snikch/goodman/cmd/goodman
-  #           make contract-tests
-
 workflows:
   version: 2
   test-suite:
     jobs:
-      - deploy_docs:
-          context: tendermint-docs
-          filters:
-            branches:
-              only:
-                - master
-            tags:
-              only:
-                - /^v.*/
-      - deploy_docs:
-          context: tendermint-docs-staging
-          filters:
-            branches:
-              only:
-                - docs-staging
       - setup_dependencies
       - test_abci_apps:
           requires:
@@ -415,12 +316,6 @@ workflows:
       - upload_coverage:
           requires:
             - test_cover
-      - reproducible_builds:
-          filters:
-            branches:
-              only:
-                - master
-                - /v[0-9]+\.[0-9]+/
       # - contract_tests:
       #     requires:
       #       - setup_dependencies
@@ -439,12 +334,3 @@ workflows:
             branches:
               only:
                 - /v[0-9]+\.[0-9]+/
-      - release_docker:
-          requires:
-            - prepare_build
-            - build_artifacts
-          filters:
-            branches:
-              only:
-                - /v[0-9]+\.[0-9]+/
-                - master

--- a/scripts/release_management/zip-file.py
+++ b/scripts/release_management/zip-file.py
@@ -25,7 +25,7 @@ def zip_asset(file,destination,arcname,version,goos,goarch):
 
 if __name__ == "__main__":
   parser = argparse.ArgumentParser()
-  parser.add_argument("--file", default="build/tendermint_{0}_{1}".format(os.environ.get('GOOS'),os.environ.get('GOARCH')), help="File to zip")
+  parser.add_argument("--file", default="build/lazyledger-core_{0}_{1}".format(os.environ.get('GOOS'),os.environ.get('GOARCH')), help="File to zip")
   parser.add_argument("--destination", default="build", help="Destination folder for files")
   parser.add_argument("--version", default=os.environ.get('CIRCLE_TAG'), help="Version number for binary, e.g.: v1.0.0")
   parser.add_argument("--goos", default=os.environ.get('GOOS'), help="GOOS parameter")
@@ -39,6 +39,6 @@ if __name__ == "__main__":
   if args.goarch is None:
     raise parser.error("argument --goarch is required")
 
-  file = zip_asset(args.file,args.destination,"tendermint",args.version,args.goos,args.goarch)
+  file = zip_asset(args.file,args.destination,"lazyledger-core",args.version,args.goos,args.goarch)
   print(file)
 


### PR DESCRIPTION
Remove not required jobs and fix paths in circlci config. We can probably remove a few more later (or switch to github actions step by step).