### PR TITLE
types: fixes typo causing the roots not be hashed

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -25,3 +25,5 @@ Friendly reminder, we have a [bug bounty program](https://hackerone.com/tendermi
 - [statesync] \#5516 Check that all heights necessary to rebuild state for a snapshot exist before adding the snapshot to the pool. (@erikgrinaker)
 
 ### BUG FIXES
+
+- [types] /#97 Fixes a typo that causes the row roots of the datasquare to be included in the DataAvailabilty header twice. (@evan-forbes)

--- a/types/block.go
+++ b/types/block.go
@@ -89,7 +89,7 @@ func (dah *DataAvailabilityHeader) Hash() []byte {
 	for i, rowRoot := range dah.RowsRoots {
 		slices[i] = rowRoot.Bytes()
 	}
-	for i, colRoot := range dah.RowsRoots {
+	for i, colRoot := range dah.ColumnRoots {
 		slices[i+colsCount] = colRoot.Bytes()
 	}
 	// The single data root is computed using a simple binary merkle tree.


### PR DESCRIPTION
I'm not 100% certain this needs to be changed, so please disregard if not.

## Description

Fixes a typo causing an incorrect root hash of the data availability header by iterating over the column roots along with the row roots, as opposed to iterating over the row roots twice.

