### PR TITLE
types: Fixes a typo to map the length of row roots and column roots t…

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -27,3 +27,5 @@ Friendly reminder, we have a [bug bounty program](https://hackerone.com/tendermi
 ### BUG FIXES
 
 - [types] /#97 Fixes a typo that causes the row roots of the datasquare to be included in the DataAvailabilty header twice. (@evan-forbes)
+
+- [types] /#114 Fixes a typo to map the length of row roots and column roots to correct variables and mitigate confusion. (@raneet10)

--- a/types/block.go
+++ b/types/block.go
@@ -83,8 +83,8 @@ func (dah *DataAvailabilityHeader) Hash() []byte {
 	if dah == nil {
 		return merkle.HashFromByteSlices(nil)
 	}
-	colsCount := len(dah.RowsRoots)
-	rowsCount := len(dah.ColumnRoots)
+	colsCount := len(dah.ColumnRoots)
+	rowsCount := len(dah.RowsRoots)
 	slices := make([][]byte, colsCount+rowsCount)
 	for i, rowRoot := range dah.RowsRoots {
 		slices[i] = rowRoot.Bytes()


### PR DESCRIPTION
…o correct variables and mitigate confusion(#114)

## Description
This change is to improve readability and does not modify the functionality since `Block.Data` is a square matrix.




