### PR TITLE
Add slack web-hook to be notified about e2e tests

### DIFF
--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -45,7 +45,7 @@ jobs:
         uses: rtCamp/action-slack-notify@ae4223259071871559b6e9d08b24a63d71b3f0c0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_CHANNEL: tendermint-internal
+          SLACK_CHANNEL: lazyledger-core
           SLACK_USERNAME: Nightly E2E Tests
           SLACK_ICON_EMOJI: ':skull:'
           SLACK_COLOR: danger


### PR DESCRIPTION
## Description

Add slack webhook. See https://github.com/rtCamp/action-slack-notify

Closes: #99

