### PR TITLE
crypto/secp256k1: fix .String()

### DIFF
--- a/crypto/secp256k1/secp256k1.go
+++ b/crypto/secp256k1/secp256k1.go
@@ -158,7 +158,7 @@ func (pubKey PubKey) Bytes() []byte {
 }
 
 func (pubKey PubKey) String() string {
-	return fmt.Sprintf("PubKeySecp256k1{%X}", pubKey[:])
+	return fmt.Sprintf("PubKeySecp256k1{%X}", []byte(pubKey))
 }
 
 func (pubKey PubKey) Equals(other crypto.PubKey) bool {


### PR DESCRIPTION
## Description

- wrap the key in []Byte() to avoid overflow.
- fixes e2e failure

This is already in Tendermint just hasn't been added to LL