### PR TITLE
Add NodeInterface

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -169,6 +169,16 @@ func StateProvider(stateProvider statesync.StateProvider) Option {
 
 //------------------------------------------------------------------------------
 
+type NodeInterface interface {
+	service.Service
+
+	ConfigureRPC() error
+	GetLogger() log.Logger
+	EventBus() *types.EventBus
+}
+
+var _ NodeInterface = &Node{}
+
 // Node is the highest level interface to a full Tendermint node.
 // It includes all configuration information and running services.
 type Node struct {
@@ -1198,6 +1208,10 @@ func (n *Node) EvidencePool() *evidence.Pool {
 // EventBus returns the Node's EventBus.
 func (n *Node) EventBus() *types.EventBus {
 	return n.eventBus
+}
+
+func (n *Node) GetLogger() log.Logger {
+	return n.Logger
 }
 
 // PrivValidator returns the Node's PrivValidator.

--- a/rpc/client/local/local.go
+++ b/rpc/client/local/local.go
@@ -49,9 +49,9 @@ type Local struct {
 // you can only have one node per process.  So make sure test cases
 // don't run in parallel, or try to simulate an entire network in
 // one process...
-func New(node *nm.Node) *Local {
+func New(node nm.NodeInterface) *Local {
 	if err := node.ConfigureRPC(); err != nil {
-		node.Logger.Error("Error configuring RPC", "err", err)
+		node.GetLogger().Error("Error configuring RPC", "err", err)
 	}
 	return &Local{
 		EventBus: node.EventBus(),


### PR DESCRIPTION
Because Node is used directly (in tendermint/lazyledger-core and cosmos-sdk), there is no easy way to replace it.
Introduced interface opens a way to replacing Tendermint node in cosmos-sdk easily.

It would be great, if we can push similar change upstream. 