### PR TITLE
Prevent double writes of samples to IPFS

### DIFF
--- a/p2p/ipld/plugin/nodes/nodes.go
+++ b/p2p/ipld/plugin/nodes/nodes.go
@@ -207,6 +207,7 @@ func prependNode(newNode node.Node, nodes []node.Node) []node.Node {
 type NmtNodeAdder struct {
 	batch *format.Batch
 	ctx   context.Context
+	leaves *cid.Set
 }
 
 // NewNmtNodeAdder returns a new NmtNodeAdder with the provided context and
@@ -215,6 +216,7 @@ func NewNmtNodeAdder(ctx context.Context, batch *format.Batch) *NmtNodeAdder {
 	return &NmtNodeAdder{
 		batch: batch,
 		ctx:   ctx,
+		leaves: cid.NewSet(),
 	}
 }
 
@@ -223,10 +225,12 @@ func (n *NmtNodeAdder) Visit(hash []byte, children ...[]byte) {
 	cid := mustCidFromNamespacedSha256(hash)
 	switch len(children) {
 	case 1:
-		n.batch.Add(n.ctx, nmtLeafNode{
-			cid:  cid,
-			Data: children[0],
-		})
+		if n.leaves.Visit(cid) {
+			n.batch.Add(n.ctx, nmtLeafNode{
+				cid:  cid,
+				Data: children[0],
+			})
+		}
 	case 2:
 		n.batch.Add(n.ctx, nmtNode{
 			cid: cid,

--- a/p2p/ipld/plugin/nodes/nodes.go
+++ b/p2p/ipld/plugin/nodes/nodes.go
@@ -205,8 +205,8 @@ func prependNode(newNode node.Node, nodes []node.Node) []node.Node {
 // NmtNodeAdder adds ipld.Nodes to the underlying ipld.Batch if it is inserted
 // into an nmt tree
 type NmtNodeAdder struct {
-	batch *format.Batch
 	ctx   context.Context
+	batch *format.Batch
 	leaves *cid.Set
 }
 

--- a/types/block.go
+++ b/types/block.go
@@ -318,10 +318,11 @@ func (b *Block) PutBlock(ctx context.Context, nodeAdder format.NodeAdder) error 
 	// add namespaces to erasured shares and flatten the eds
 	leaves := flattenNamespacedEDS(namespacedShares, eds)
 
+	// create nmt adder wrapping batch adder
+	batchAdder := nodes.NewNmtNodeAdder(ctx, format.NewBatch(ctx, nodeAdder))
+
 	// iterate through each set of col and row leaves
 	for _, leafSet := range leaves {
-		// create a batch per each leafSet
-		batchAdder := nodes.NewNmtNodeAdder(ctx, format.NewBatch(ctx, nodeAdder))
 		tree := nmt.New(sha256.New(), nmt.NodeVisitor(batchAdder.Visit))
 		for _, share := range leafSet {
 			err = tree.Push(share)

--- a/types/block.go
+++ b/types/block.go
@@ -333,15 +333,10 @@ func (b *Block) PutBlock(ctx context.Context, nodeAdder format.NodeAdder) error 
 
 		// compute the root in order to collect the ipld.Nodes
 		tree.Root()
-
-		// commit the batch to ipfs
-		err = batchAdder.Batch().Commit()
-		if err != nil {
-			return err
-		}
 	}
 
-	return nil
+	// commit the batch to ipfs
+	return batchAdder.Batch().Commit()
 }
 
 // flattenNamespacedEDS returns a flattend extendedDataSquare with namespaces


### PR DESCRIPTION
## Problem
As we compute the NMT tree for columns and rows of shares in an extended data square, we end up adding all the shares into IPFS two times, thus introducing unnecessary overhead, especially for IO. Considering how big blocks may become and how quickly they are generated, the overhead would scale significantly.

## Solution
The PR introduces a simple patch in NMTNodeAdder to memoize added leaves not to be added a second time.

EDIT:
It also fixes incorrect use of `BatchAdder`

EDIT2:
Closes #204