### PR TITLE
Stop using the pinning option as a default

### DIFF
--- a/consensus/state.go
+++ b/consensus/state.go
@@ -1116,7 +1116,7 @@ func (cs *State) defaultDecideProposal(height int64, round int32) {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*1500)
 		defer cancel()
 		// TODO: post data to IPFS in a goroutine
-		err := block.PutBlock(ctx, cs.IpfsAPI.Dag().Pinning())
+		err := block.PutBlock(ctx, cs.IpfsAPI.Dag())
 		if err != nil {
 			cs.Logger.Error(fmt.Sprintf("failure to post block data to IPFS: %s", err.Error()))
 		}

--- a/p2p/ipld/read_test.go
+++ b/p2p/ipld/read_test.go
@@ -108,7 +108,7 @@ func TestGetLeafData(t *testing.T) {
 
 	// create the context and batch needed for node collection from the tree
 	ctx := context.Background()
-	batch := format.NewBatch(ctx, ipfsAPI.Dag().Pinning())
+	batch := format.NewBatch(ctx, ipfsAPI.Dag())
 
 	// generate random data for the nmt
 	data := generateRandNamespacedRawData(16, types.NamespaceSize, types.ShareSize)


### PR DESCRIPTION
## Description

During block proposal and testing, we are currently pinning data to IPFS by default. Pinning has significant overhead, so much so that it's causing the tests to timeout. This PR removes the default pinning option from block proposal and testing.|
 
Closes: #275

