### PR TITLE
Fix empty block retrieval

### DIFF
--- a/p2p/ipld/nmt_wrapper.go
+++ b/p2p/ipld/nmt_wrapper.go
@@ -57,7 +57,7 @@ func (w *ErasuredNamespacedMerkleTree) Push(data []byte, idx rsmt2d.SquareIndex)
 	if idx.Axis+1 > uint(w.squareSize) || idx.Cell+1 > uint(w.squareSize) {
 		copy(nsID, types.ParitySharesNamespaceID)
 	} else {
-		if bytes.Equal(data[:types.NamespaceSize], nsID){
+		if bytes.Equal(data[:types.NamespaceSize], nsID) {
 			copy(nsID, types.TailPaddingNamespaceID)
 		} else {
 			copy(nsID, data[:types.NamespaceSize])

--- a/p2p/ipld/nmt_wrapper.go
+++ b/p2p/ipld/nmt_wrapper.go
@@ -1,12 +1,14 @@
 package ipld
 
 import (
+	"bytes"
 	"crypto/sha256"
 
-	"github.com/lazyledger/lazyledger-core/types"
 	"github.com/lazyledger/nmt"
 	"github.com/lazyledger/nmt/namespace"
 	"github.com/lazyledger/rsmt2d"
+
+	"github.com/lazyledger/lazyledger-core/types"
 )
 
 // Fulfills the rsmt2d.Tree interface and rsmt2d.TreeConstructorFn function
@@ -55,7 +57,11 @@ func (w *ErasuredNamespacedMerkleTree) Push(data []byte, idx rsmt2d.SquareIndex)
 	if idx.Axis+1 > uint(w.squareSize) || idx.Cell+1 > uint(w.squareSize) {
 		copy(nsID, types.ParitySharesNamespaceID)
 	} else {
-		copy(nsID, data[:types.NamespaceSize])
+		if bytes.Equal(data[:types.NamespaceSize], nsID){
+			copy(nsID, types.TailPaddingNamespaceID)
+		} else {
+			copy(nsID, data[:types.NamespaceSize])
+		}
 	}
 	nidAndData := append(append(make([]byte, 0, types.NamespaceSize+len(data)), nsID...), data...)
 	// push to the underlying tree

--- a/p2p/ipld/nmt_wrapper.go
+++ b/p2p/ipld/nmt_wrapper.go
@@ -52,8 +52,8 @@ func (w *ErasuredNamespacedMerkleTree) Push(data []byte, idx rsmt2d.SquareIndex)
 		panic("pushed past predetermined square size")
 	}
 
-	// use the parity namespace if the cell is not in Q0 of the extended
-	// datasquare
+	// use the parity namespace if the cell is not in Q0 of the extended datasquare
+	// if the cell is empty it means we got an empty block so we need to use TailPaddingNamespaceID
 	if idx.Axis+1 > uint(w.squareSize) || idx.Cell+1 > uint(w.squareSize) {
 		copy(nsID, types.ParitySharesNamespaceID)
 	} else {

--- a/p2p/ipld/read_test.go
+++ b/p2p/ipld/read_test.go
@@ -302,6 +302,25 @@ func TestRetrieveBlockData(t *testing.T) {
 	}
 }
 
+func TestPutRetrieveEmptyBlock(t *testing.T) {
+	// create the context and batch needed for node collection from the tree
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// issue a new API object
+	ipfsAPI := mockedIpfsAPI(t)
+
+	block := types.Block{LastCommit: &types.Commit{}}
+	block.Hash()
+
+	err := block.PutBlock(ctx, ipfsAPI.Dag())
+	require.NoError(t, err)
+
+	data, err := RetrieveBlockData(ctx, &block.DataAvailabilityHeader, ipfsAPI, types.DefaultCodec())
+	assert.NoError(t, err)
+	assert.NotNil(t, data)
+}
+
 func flatten(eds *rsmt2d.ExtendedDataSquare) [][]byte {
 	flattenedEDSSize := eds.Width() * eds.Width()
 	out := make([][]byte, flattenedEDSSize)

--- a/p2p/ipld/read_test.go
+++ b/p2p/ipld/read_test.go
@@ -229,6 +229,7 @@ func TestRetrieveBlockData(t *testing.T) {
 	adjustedMsgSize := types.MsgShareSize - 2
 
 	tests := []test{
+		{"Empty block", 1, false, ""},
 		{"4 KB block", 4, false, ""},
 		{"16 KB block", 8, false, ""},
 		{"16 KB block timeout expected", 8, true, "timeout"},
@@ -300,25 +301,6 @@ func TestRetrieveBlockData(t *testing.T) {
 			assert.Equal(t, rawData, nsShares.RawShares())
 		})
 	}
-}
-
-func TestPutRetrieveEmptyBlock(t *testing.T) {
-	// create the context and batch needed for node collection from the tree
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	// issue a new API object
-	ipfsAPI := mockedIpfsAPI(t)
-
-	block := types.Block{LastCommit: &types.Commit{}}
-	block.Hash()
-
-	err := block.PutBlock(ctx, ipfsAPI.Dag())
-	require.NoError(t, err)
-
-	data, err := RetrieveBlockData(ctx, &block.DataAvailabilityHeader, ipfsAPI, types.DefaultCodec())
-	assert.NoError(t, err)
-	assert.NotNil(t, data)
 }
 
 func flatten(eds *rsmt2d.ExtendedDataSquare) [][]byte {
@@ -410,6 +392,9 @@ func rootsToDigests(roots [][]byte) []namespace.IntervalDigest {
 
 func generateRandomBlockData(msgCount, msgSize int) types.Data {
 	var out types.Data
+	if msgCount == 1 {
+		return out
+	}
 	out.Messages = generateRandomMessages(msgCount-1, msgSize)
 	out.Txs = generateRandomContiguousShares(1)
 	return out


### PR DESCRIPTION
So I've finally managed to find the issue which caused RetrieveBlockData not to work in #293. The problem was in the wrong root calculation in wrapped NMT for empty blocks.

P.S. This was my first adventure through the whole rsmt2 stack and it took unexpectedly long to find out the problem is still somewhere in LL. Original symptoms were too confusing but was kind of fun 🍵 