### PR TITLE
Use squares with a width that is a power of two

### DIFF
--- a/p2p/ipld/read.go
+++ b/p2p/ipld/read.go
@@ -245,7 +245,7 @@ func GetLeafData(
 
 func leafPath(index, total uint32) ([]string, error) {
 	// ensure that the total is a power of two
-	if isPowerOf2(total) {
+	if !isPowerOf2(total) {
 		return nil, fmt.Errorf("expected total to be a power of 2, got %d", total)
 	}
 

--- a/p2p/ipld/read.go
+++ b/p2p/ipld/read.go
@@ -2,7 +2,6 @@ package ipld
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"math"
 	"math/rand"
@@ -246,8 +245,8 @@ func GetLeafData(
 
 func leafPath(index, total uint32) ([]string, error) {
 	// ensure that the total is a power of two
-	if total != nextPowerOf2(total) {
-		return nil, errors.New("expected total to be a power of 2")
+	if isPowerOf2(total) {
+		return nil, fmt.Errorf("expected total to be a power of 2, got %d", total)
 	}
 
 	if total == 0 {
@@ -269,29 +268,7 @@ func leafPath(index, total uint32) ([]string, error) {
 	return path, nil
 }
 
-// nextPowerOf2 returns the next lowest power of 2 unless the input is a power
-// of two, in which case it returns the input
-func nextPowerOf2(v uint32) uint32 {
-	if v == 1 {
-		return 1
-	}
-	// keep track of the input
-	i := v
-
-	// find the next highest power using bit mashing
-	v--
-	v |= v >> 1
-	v |= v >> 2
-	v |= v >> 4
-	v |= v >> 8
-	v |= v >> 16
-	v++
-
-	// check if the input was the next highest power
-	if i == v {
-		return v
-	}
-
-	// return the next lowest power
-	return v / 2
+// isPowerOf2 returns checks if a given number is a power of two
+func isPowerOf2(v uint32) bool {
+	return math.Ceil(math.Log2(float64(v))) == math.Floor(math.Log2(float64(v)))
 }

--- a/p2p/ipld/read_test.go
+++ b/p2p/ipld/read_test.go
@@ -58,36 +58,41 @@ func TestLeafPath(t *testing.T) {
 	}
 }
 
-func TestNextPowerOf2(t *testing.T) {
+func Test_isPowerOf2(t *testing.T) {
 	type test struct {
 		input    uint32
-		expected uint32
+		expected bool
 	}
 	tests := []test{
 		{
 			input:    2,
-			expected: 2,
+			expected: true,
 		},
 		{
 			input:    11,
-			expected: 8,
+			expected: false,
 		},
 		{
 			input:    511,
-			expected: 256,
+			expected: false,
+		},
+
+		{
+			input:    0,
+			expected: true,
 		},
 		{
 			input:    1,
-			expected: 1,
+			expected: true,
 		},
 		{
-			input:    0,
-			expected: 0,
+			input:    16,
+			expected: true,
 		},
 	}
 	for _, tt := range tests {
-		res := nextPowerOf2(tt.input)
-		assert.Equal(t, tt.expected, res)
+		res := isPowerOf2(tt.input)
+		assert.Equal(t, tt.expected, res, fmt.Sprintf("input was %d", tt.input))
 	}
 }
 

--- a/types/block.go
+++ b/types/block.go
@@ -1382,7 +1382,7 @@ func (data *Data) ComputeShares() (NamespacedShares, int) {
 	curLen := len(txShares) + len(intermRootsShares) + len(evidenceShares) + len(msgShares)
 
 	// find the number of shares needed to create a square that has a power of
-	// two
+	// two width
 	wantLen := paddedLen(curLen)
 
 	// ensure that the min square size is used
@@ -1404,15 +1404,15 @@ func (data *Data) ComputeShares() (NamespacedShares, int) {
 // given the current number of shares
 func paddedLen(length int) int {
 	width := uint32(math.Ceil(math.Sqrt(float64(length))))
-	width = nextPowerOf2(width)
+	width = nextHighestPowerOf2(width)
 	return int(width * width)
 }
 
-// nextPowerOf2 returns the next lowest power of 2 unless the input is a power
+// nextPowerOf2 returns the next highest power of 2 unless the input is a power
 // of two, in which case it returns the input
-func nextPowerOf2(v uint32) uint32 {
-	if v == 1 {
-		return 1
+func nextHighestPowerOf2(v uint32) uint32 {
+	if v == 0 {
+		return 0
 	}
 
 	// find the next highest power using bit mashing
@@ -1424,7 +1424,7 @@ func nextPowerOf2(v uint32) uint32 {
 	v |= v >> 16
 	v++
 
-	// return the next lowest power
+	// return the next highest power
 	return v
 }
 

--- a/types/block.go
+++ b/types/block.go
@@ -1381,7 +1381,8 @@ func (data *Data) ComputeShares() (NamespacedShares, int) {
 	msgShares := data.Messages.splitIntoShares()
 	curLen := len(txShares) + len(intermRootsShares) + len(evidenceShares) + len(msgShares)
 
-	// find the
+	// find the number of shares needed to create a square that has a power of
+	// two
 	wantLen := paddedLen(curLen)
 
 	// ensure that the min square size is used

--- a/types/block_test.go
+++ b/types/block_test.go
@@ -1398,6 +1398,66 @@ func TestPutBlock(t *testing.T) {
 	}
 }
 
+func TestPaddedLength(t *testing.T) {
+	type test struct {
+		input, expected int
+	}
+	tests := []test{
+		{0, 0},
+		{1, 1},
+		{2, 4},
+		{4, 4},
+		{5, 16},
+		{11, 16},
+		{128, 256},
+	}
+	for _, tt := range tests {
+		res := paddedLen(tt.input)
+		assert.Equal(t, tt.expected, res)
+	}
+}
+
+func TestNextPowerOf2(t *testing.T) {
+	type test struct {
+		input    uint32
+		expected uint32
+	}
+	tests := []test{
+		{
+			input:    2,
+			expected: 2,
+		},
+		{
+			input:    11,
+			expected: 16,
+		},
+		{
+			input:    511,
+			expected: 512,
+		},
+		{
+			input:    1,
+			expected: 1,
+		},
+		{
+			input:    0,
+			expected: 0,
+		},
+		{
+			input:    5,
+			expected: 8,
+		},
+		{
+			input:    6,
+			expected: 8,
+		},
+	}
+	for _, tt := range tests {
+		res := nextPowerOf2(tt.input)
+		assert.Equal(t, tt.expected, res)
+	}
+}
+
 func generateRandomMsgOnlyData(msgCount int) Data {
 	out := make([]Message, msgCount)
 	for i, msg := range generateRandNamespacedRawData(msgCount, NamespaceSize, MsgShareSize-2) {

--- a/types/block_test.go
+++ b/types/block_test.go
@@ -1417,7 +1417,7 @@ func TestPaddedLength(t *testing.T) {
 	}
 }
 
-func TestNextPowerOf2(t *testing.T) {
+func TestNextHighestPowerOf2(t *testing.T) {
 	type test struct {
 		input    uint32
 		expected uint32
@@ -1451,9 +1451,13 @@ func TestNextPowerOf2(t *testing.T) {
 			input:    6,
 			expected: 8,
 		},
+		{
+			input:    16,
+			expected: 16,
+		},
 	}
 	for _, tt := range tests {
-		res := nextPowerOf2(tt.input)
+		res := nextHighestPowerOf2(tt.input)
 		assert.Equal(t, tt.expected, res)
 	}
 }


### PR DESCRIPTION
## Description

This PR simply changes the way the number of tail padding shares are calculated in order to make squares with widths that are powers of two. However, this PR does not add any code that purposefully creates squares of a certain size. 

Closes: #257 

