### PR TITLE
Debugg CI for #334

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -844,16 +844,16 @@ func DefaultConsensusConfig() *ConsensusConfig {
 // TestConsensusConfig returns a configuration for testing the consensus service
 func TestConsensusConfig() *ConsensusConfig {
 	cfg := DefaultConsensusConfig()
-	cfg.TimeoutPropose = 40 * time.Millisecond
-	cfg.TimeoutProposeDelta = 1 * time.Millisecond
-	cfg.TimeoutPrevote = 10 * time.Millisecond
-	cfg.TimeoutPrevoteDelta = 1 * time.Millisecond
-	cfg.TimeoutPrecommit = 10 * time.Millisecond
-	cfg.TimeoutPrecommitDelta = 1 * time.Millisecond
+	cfg.TimeoutPropose = 100 * time.Millisecond
+	cfg.TimeoutProposeDelta = 10 * time.Millisecond
+	cfg.TimeoutPrevote = 40 * time.Millisecond
+	cfg.TimeoutPrevoteDelta = 10 * time.Millisecond
+	cfg.TimeoutPrecommit = 40 * time.Millisecond
+	cfg.TimeoutPrecommitDelta = 10 * time.Millisecond
 	// NOTE: when modifying, make sure to update time_iota_ms (testGenesisFmt) in toml.go
-	cfg.TimeoutCommit = 10 * time.Millisecond
+	cfg.TimeoutCommit = 40 * time.Millisecond
 	cfg.SkipTimeoutCommit = true
-	cfg.PeerGossipSleepDuration = 5 * time.Millisecond
+	cfg.PeerGossipSleepDuration = 10 * time.Millisecond
 	cfg.PeerQueryMaj23SleepDuration = 250 * time.Millisecond
 	cfg.DoubleSignCheckHeight = int64(0)
 	return cfg

--- a/consensus/common_test.go
+++ b/consensus/common_test.go
@@ -52,7 +52,7 @@ type cleanupFunc func()
 var (
 	config                *cfg.Config // NOTE: must be reset for each _test.go file
 	consensusReplayConfig *cfg.Config
-	ensureTimeout         = 600 * time.Millisecond
+	ensureTimeout         = 1000 * time.Millisecond
 )
 
 func ensureDir(dir string, mode os.FileMode) {

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/gogo/protobuf/proto"
-	iface "github.com/ipfs/interface-go-ipfs-core"
 	ipfsapi "github.com/ipfs/interface-go-ipfs-core"
 	cfg "github.com/lazyledger/lazyledger-core/config"
 	cstypes "github.com/lazyledger/lazyledger-core/consensus/types"
@@ -209,7 +208,7 @@ func NewState(
 // Public interface
 
 // SetIPFSApi sets the IPFSAPI
-func (cs *State) SetIPFSApi(api iface.CoreAPI) {
+func (cs *State) SetIPFSApi(api ipfsapi.CoreAPI) {
 	cs.mtx.Lock()
 	defer cs.mtx.Unlock()
 	cs.IpfsAPI = api

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/gogo/protobuf/proto"
+	iface "github.com/ipfs/interface-go-ipfs-core"
 	ipfsapi "github.com/ipfs/interface-go-ipfs-core"
 	cfg "github.com/lazyledger/lazyledger-core/config"
 	cstypes "github.com/lazyledger/lazyledger-core/consensus/types"
@@ -206,6 +207,13 @@ func NewState(
 
 //----------------------------------------
 // Public interface
+
+// SetIPFSApi sets the IPFSAPI
+func (cs *State) SetIPFSApi(api iface.CoreAPI) {
+	cs.mtx.Lock()
+	defer cs.mtx.Unlock()
+	cs.IpfsAPI = api
+}
 
 // SetLogger implements Service.
 func (cs *State) SetLogger(l log.Logger) {

--- a/node/node.go
+++ b/node/node.go
@@ -937,7 +937,7 @@ func (n *Node) OnStart() error {
 	if err != nil {
 		return fmt.Errorf("failed to get IPFS API: %w", err)
 	}
-	n.consensusState.IpfsAPI = n.ipfsAPI
+	n.consensusState.SetIPFSApi(n.ipfsAPI)
 
 	return nil
 }

--- a/p2p/ipld/race_detector_file.go
+++ b/p2p/ipld/race_detector_file.go
@@ -1,7 +1,0 @@
-// +build race
-
-package ipld
-
-func init() {
-	raceDetectorActive = true
-}

--- a/p2p/ipld/racedetector/is_active.go
+++ b/p2p/ipld/racedetector/is_active.go
@@ -1,0 +1,7 @@
+package racedetector
+
+var raceDetectorActive = false
+
+func IsActive() bool {
+	return raceDetectorActive
+}

--- a/p2p/ipld/racedetector/race_detector_file.go
+++ b/p2p/ipld/racedetector/race_detector_file.go
@@ -1,0 +1,7 @@
+// +build race
+
+package racedetector
+
+func init() {
+	raceDetectorActive = true
+}

--- a/p2p/ipld/read_test.go
+++ b/p2p/ipld/read_test.go
@@ -24,10 +24,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/lazyledger/lazyledger-core/ipfs/plugin"
+	"github.com/lazyledger/lazyledger-core/p2p/ipld/racedetector"
 	"github.com/lazyledger/lazyledger-core/types"
 )
-
-var raceDetectorActive = true
 
 func TestLeafPath(t *testing.T) {
 	type test struct {
@@ -247,7 +246,7 @@ func TestRetrieveBlockData(t *testing.T) {
 		t.Run(fmt.Sprintf("%s size %d", tc.name, tc.squareSize), func(t *testing.T) {
 			// if we're using the race detector, skip some large tests due to time and
 			// concurrency constraints
-			if raceDetectorActive && tc.squareSize > 8 {
+			if racedetector.IsActive() && tc.squareSize > 8 {
 				t.Skip("Not running large test due to time and concurrency constraints while race detector is active.")
 			}
 

--- a/p2p/ipld/read_test.go
+++ b/p2p/ipld/read_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/lazyledger/lazyledger-core/types"
 )
 
-var raceDetectorActive = false
+var raceDetectorActive = true
 
 func TestLeafPath(t *testing.T) {
 	type test struct {


### PR DESCRIPTION
## Description

put the race detector file for the ipld/read_test.go in its own package. Locally, this doesn't make a difference, but the CI fails otherwise... still don't know why. 

Resorted to increasing the timeouts to make the consensus tests more reliable.

note: merging into #334, not master

Closes: #XXX

