### PR TITLE
Define default configuration for embedded IPFS in FullNode

### DIFF
--- a/ipfs/defaults.go
+++ b/ipfs/defaults.go
@@ -8,7 +8,7 @@ import (
 )
 
 // BootstrapPeers is a list of default bootstrap peers for IPFS network
-// TODO: Change this to LL defaults at some point
+// TODO(Wondertan): Change this to LL defaults at some point
 var BootstrapPeers, _ = ipfscfg.DefaultBootstrapPeers()
 
 // DefaultFullNodeConfig provides default embedded IPFS configuration for FullNode

--- a/ipfs/defaults.go
+++ b/ipfs/defaults.go
@@ -22,7 +22,7 @@ func DefaultFullNodeConfig() (*ipfscfg.Config, error) {
 
 	var conf = &ipfscfg.Config{
 		// ed25519 PKI identity for p2p communication
-		// TODO: Any reason not reuse ed25519 key from consensus identity?
+		// TODO(Wondertan): Any reason not reuse ed25519 key from consensus identity?
 		Identity: identity,
 		// List of libp2p peer addresses the node automatically connects on start
 		Bootstrap: ipfscfg.BootstrapPeerStrings(BootstrapPeers),

--- a/ipfs/defaults.go
+++ b/ipfs/defaults.go
@@ -1,0 +1,200 @@
+package ipfs
+
+import (
+	"os"
+
+	ipfscfg "github.com/ipfs/go-ipfs-config"
+	"github.com/ipfs/interface-go-ipfs-core/options"
+)
+
+// BootstrapPeers is a list of default bootstrap peers for IPFS network
+// TODO: Change this to LL defaults at some point
+var BootstrapPeers, _ = ipfscfg.DefaultBootstrapPeers()
+
+func DefaultFullNodeConfig() (*ipfscfg.Config, error) {
+	identity, err := ipfscfg.CreateIdentity(os.Stdout, []options.KeyGenerateOption{
+		options.Key.Type(options.Ed25519Key),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var conf = &ipfscfg.Config{
+		// ed25519 PKI identity for p2p communication
+		// TODO: Any reason not reuse ed25519 key from consensus identity?
+		Identity: identity,
+		// List of libp2p peer addresses the node automatically connects on start
+		Bootstrap: ipfscfg.BootstrapPeerStrings(BootstrapPeers),
+		// Configure all the addresses the node listens to
+		Addresses: ipfscfg.Addresses{
+			// List of libp2p addresses to listen to
+			Swarm: []string{
+				// listen on all network interfaces.
+				// NOTE: We don't use IPv6 for now, but we might add support for it at some point.
+				"/ip4/0.0.0.0/tcp/4001",
+			},
+			API: []string{
+				"/ip4/127.0.0.1/tcp/5001",
+			},
+			// List of public libp2p WAN address the Node can be connected with
+			// NOTE: Should be configured by Node administrator manually
+			Announce: nil,
+			// List of libp2p address the Node listens to but not accessible from the WAN.
+			// It's a good manner to fil this, as that preserves connected peers from trying connections to those
+			// NOTE: Should be configured by Node administrator manually
+			NoAnnounce: nil,
+			// List of addresses IPFS API server listens to
+			// we do not run IPFS Gateway
+			Gateway: nil,
+		},
+		// Networking configuration
+		Swarm: ipfscfg.SwarmConfig{
+			// auto port forwarding is nice
+			DisableNatPortMap: false,
+			// metrics are useful
+			DisableBandwidthMetrics: false,
+			// relays are cool from engineering standpoint, but don't use them
+			EnableRelayHop: false, EnableAutoRelay: false,
+			// ConnMgr manager controls the amount of conns a Node holds. If the amount of conns hits HighWater, ConnMgr
+			// trims amount of connections down to LowWater
+			// NOTE: Connections can by prioritized using Tagging in ConnMgr in order to keep important conns alive
+			ConnMgr: ipfscfg.ConnMgr{
+				// we use defaults from IPFS for HighWater
+				HighWater: 900,
+				// we use defaults from IPFS for HighWater
+				LowWater: 600,
+				// defines how often ConnMgr should check conns for trimming, we use default from IPFS
+				GracePeriod: "20s",
+				// just a basic connection manager
+				Type: "basic",
+			},
+			// Configuration for all networking protocols
+			Transports: ipfscfg.Transports{
+				Network: transport{
+					// we default to TCP as it's most common, battle tested transport, but we may migrate to the one below
+					TCP: ipfscfg.False,
+					// we might default to QUIC at some point, but for now TCP is more common and reliable
+					QUIC: ipfscfg.False,
+					// we don't use Websocket as we don't target for browser nodes
+					Websocket: ipfscfg.False,
+					// we don't use relays as it's expensive in terms of traffic for relay nodes
+					Relay: ipfscfg.False,
+				},
+				// Security protocol wraps IO conns in a private encrypted tunnel
+				Security: security{
+					// we default to Noise, as it's designed for p2p interactions in the first place and is 0-RTT
+					Noise: ipfscfg.DefaultPriority,
+					// we don't use SECIO as it's now deprecated and has know issues
+					SECIO: ipfscfg.Disabled,
+					// we don't allow TLS option, even it's a production ready protocol, to lower bug vectors
+					TLS: ipfscfg.Disabled,
+				},
+				// Multiplexers provide ability to run multiple logical streams over one transport stream, e.g TCP conn
+				Multiplexers: multiplexers{
+					// we default to Yamux due to production readiness
+					Yamux: ipfscfg.DefaultPriority,
+					// we don't use Mplex as it's more like a toy multiplexer for testings and etc
+					Mplex: ipfscfg.Disabled,
+				},
+			},
+			// this ia manual peer blacklist
+			AddrFilters: nil,
+		},
+		// Persistent KV store configuration
+		Datastore: ipfscfg.Datastore{
+			// Configuration for badger kv we default to
+			Spec: map[string]interface{}{
+				"type":   "measure",
+				"prefix": "badger.datastore",
+				"child": map[string]interface{}{
+					"type":       "badgerds",
+					"path":       "badgerds",
+					"syncWrites": false,
+					"truncate":   true,
+				},
+			},
+			// we don't use bloom filtered blockstore
+			BloomFilterSize: 0,
+			// we don't use GC so values below does not have any affect
+			StorageGCWatermark: 0,
+			GCPeriod:           "",
+			StorageMax:         "",
+		},
+		// Configuration for CID reproviding
+		// In kDHT all records have TTL, thus we have to regularly(Interval) reprovide/reannounce stored CID to the
+		// network. Otherwise information that the node stores something will be lost. Should be in tact with kDHT
+		// record cleaning configuration
+		Reprovider: ipfscfg.Reprovider{
+			Interval: "12h",
+			Strategy: "all",
+		},
+		Routing: ipfscfg.Routing{
+			// Full node must be available from the WAN thus 'dhtserver'
+			// Depending on the node type/use-case different modes should be used.
+			Type: "dhtserver",
+		},
+		// Configuration for plugins
+		Plugins: ipfscfg.Plugins{
+			// Disable preloaded but unused plugins
+			Plugins: map[string]ipfscfg.Plugin{
+				"ds-flatfs": {
+					Disabled: true,
+				},
+				"ds-level": {
+					Disabled: true,
+				},
+				"ipld-git": {
+					Disabled: true,
+				},
+			},
+		},
+		// Unused fields:
+		// we currently don't use PubSub
+		Pubsub: ipfscfg.PubsubConfig{},
+		// List of all experimental IPFS features
+		// We currently don't use any of them
+		Experimental: ipfscfg.Experiments{},
+		// bi-directional agreement between peers to hold connections with
+		Peering: ipfscfg.Peering{},
+		// local network discovery is useful, but there is no practical reason to have two FullNode in one LAN
+		Discovery: ipfscfg.Discovery{},
+		// we don't use AutoNAT service for now
+		AutoNAT: ipfscfg.AutoNATConfig{},
+		// we use API in some cases, but we do not need additional headers
+		API: ipfscfg.API{},
+		// we do not use FUSE and thus mounts
+		Mounts: ipfscfg.Mounts{},
+		// we do not use IPFS
+		Ipns: ipfscfg.Ipns{},
+		// we do not run Gateway
+		Gateway: ipfscfg.Gateway{},
+		// we don't use Pinning as we don't ues GC
+		Pinning: ipfscfg.Pinning{},
+		// unused in IPFS and/or deprecated
+		Provider: ipfscfg.Provider{},
+	}
+
+	return conf, err
+}
+
+// anonymous type aliases to keep default configuration succinct
+type (
+	//nolint
+	transport = struct {
+		QUIC      ipfscfg.Flag `json:",omitempty"`
+		TCP       ipfscfg.Flag `json:",omitempty"`
+		Websocket ipfscfg.Flag `json:",omitempty"`
+		Relay     ipfscfg.Flag `json:",omitempty"`
+	}
+	//nolint
+	security = struct {
+		TLS   ipfscfg.Priority `json:",omitempty"`
+		SECIO ipfscfg.Priority `json:",omitempty"`
+		Noise ipfscfg.Priority `json:",omitempty"`
+	}
+	//nolint
+	multiplexers = struct {
+		Yamux ipfscfg.Priority `json:",omitempty"`
+		Mplex ipfscfg.Priority `json:",omitempty"`
+	}
+)

--- a/ipfs/defaults.go
+++ b/ipfs/defaults.go
@@ -32,10 +32,10 @@ func DefaultFullNodeConfig() (*ipfscfg.Config, error) {
 			Swarm: []string{
 				// listen on all network interfaces.
 				// NOTE: We don't use IPv6 for now, but we might add support for it at some point.
-				"/ip4/0.0.0.0/tcp/4001",
+				"/ip4/0.0.0.0/tcp/16001",
 			},
 			API: []string{
-				"/ip4/127.0.0.1/tcp/5001",
+				"/ip4/127.0.0.1/tcp/17001",
 			},
 			// List of public libp2p WAN address the Node can be connected with
 			// NOTE: Should be configured by Node administrator manually
@@ -87,7 +87,7 @@ func DefaultFullNodeConfig() (*ipfscfg.Config, error) {
 					Noise: ipfscfg.DefaultPriority,
 					// we don't use SECIO as it's now deprecated and has know issues
 					SECIO: ipfscfg.Disabled,
-					// we don't allow TLS option, despite being a production ready protocol, to lower bug vectors
+					// we don't allow TLS option as we use noise only
 					TLS: ipfscfg.Disabled,
 				},
 				// Multiplexers provide ability to run multiple logical streams over one transport stream, e.g TCP conn

--- a/ipfs/defaults.go
+++ b/ipfs/defaults.go
@@ -11,6 +11,7 @@ import (
 // TODO: Change this to LL defaults at some point
 var BootstrapPeers, _ = ipfscfg.DefaultBootstrapPeers()
 
+// DefaultFullNodeConfig provides default embedded IPFS configuration for FullNode
 func DefaultFullNodeConfig() (*ipfscfg.Config, error) {
 	identity, err := ipfscfg.CreateIdentity(os.Stdout, []options.KeyGenerateOption{
 		options.Key.Type(options.Ed25519Key),

--- a/ipfs/defaults.go
+++ b/ipfs/defaults.go
@@ -87,7 +87,7 @@ func DefaultFullNodeConfig() (*ipfscfg.Config, error) {
 					Noise: ipfscfg.DefaultPriority,
 					// we don't use SECIO as it's now deprecated and has know issues
 					SECIO: ipfscfg.Disabled,
-					// we don't allow TLS option, even it's a production ready protocol, to lower bug vectors
+					// we don't allow TLS option, despite being a production ready protocol, to lower bug vectors
 					TLS: ipfscfg.Disabled,
 				},
 				// Multiplexers provide ability to run multiple logical streams over one transport stream, e.g TCP conn

--- a/ipfs/defaults.go
+++ b/ipfs/defaults.go
@@ -73,7 +73,7 @@ func DefaultFullNodeConfig() (*ipfscfg.Config, error) {
 			Transports: ipfscfg.Transports{
 				Network: transport{
 					// we default to TCP as it's most common, battle tested transport, but we may migrate to the one below
-					TCP: ipfscfg.False,
+					TCP: ipfscfg.True,
 					// we might default to QUIC at some point, but for now TCP is more common and reliable
 					QUIC: ipfscfg.False,
 					// we don't use Websocket as we don't target for browser nodes

--- a/ipfs/init.go
+++ b/ipfs/init.go
@@ -1,11 +1,7 @@
 package ipfs
 
 import (
-	"os"
-
-	ipfscfg "github.com/ipfs/go-ipfs-config"
 	"github.com/ipfs/go-ipfs/repo/fsrepo"
-	"github.com/ipfs/interface-go-ipfs-core/options"
 
 	"github.com/lazyledger/lazyledger-core/libs/log"
 	tmos "github.com/lazyledger/lazyledger-core/libs/os"
@@ -27,19 +23,13 @@ func InitRepo(path string, logger log.Logger) error {
 		return err
 	}
 
-	identity, err := ipfscfg.CreateIdentity(os.Stdout, []options.KeyGenerateOption{
-		options.Key.Type(options.Ed25519Key),
-	})
+	// TODO: Define node types, pass a node type as param and get relative config instead
+	cfg, err := DefaultFullNodeConfig()
 	if err != nil {
 		return err
 	}
 
-	conf, err := ipfscfg.InitWithIdentity(identity)
-	if err != nil {
-		return err
-	}
-
-	if err := fsrepo.Init(path, conf); err != nil {
+	if err := fsrepo.Init(path, cfg); err != nil {
 		return err
 	}
 

--- a/node/node.go
+++ b/node/node.go
@@ -633,11 +633,6 @@ func NewNode(config *cfg.Config,
 	logger log.Logger,
 	options ...Option) (*Node, error) {
 
-	ipfs, ipfsclose, err := ipfsProvider()
-	if err != nil {
-		return nil, err
-	}
-
 	blockStore, stateDB, err := initDBs(config, dbProvider)
 	if err != nil {
 		return nil, err
@@ -736,6 +731,11 @@ func NewNode(config *cfg.Config,
 		evidencePool,
 		sm.BlockExecutorWithMetrics(smMetrics),
 	)
+
+	ipfs, ipfsclose, err := ipfsProvider()
+	if err != nil {
+		return nil, err
+	}
 
 	// Make BlockchainReactor. Don't start fast sync if we're doing a state sync first.
 	bcReactor, err := createBlockchainReactor(config, state, blockExec, blockStore, fastSync && !stateSync, logger)

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -164,7 +164,7 @@ func TestNodeSetPrivValTCP(t *testing.T) {
 	defer signerServer.Stop() //nolint:errcheck // ignore for tests
 
 	logger := log.TestingLogger()
-	n, err := DefaultNewNode(config, ipfs.Embedded(true, config.IPFS, logger), logger)
+	n, err := DefaultNewNode(config, ipfs.Mock(), logger)
 	require.NoError(t, err)
 	assert.IsType(t, &privval.RetrySignerClient{}, n.PrivValidator())
 }
@@ -209,7 +209,7 @@ func TestNodeSetPrivValIPC(t *testing.T) {
 	defer pvsc.Stop() //nolint:errcheck // ignore for tests
 
 	logger := log.TestingLogger()
-	n, err := DefaultNewNode(config, ipfs.Embedded(true, config.IPFS, logger), logger)
+	n, err := DefaultNewNode(config, ipfs.Mock(), logger)
 	require.NoError(t, err)
 	assert.IsType(t, &privval.RetrySignerClient{}, n.PrivValidator())
 }

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -163,7 +163,8 @@ func TestNodeSetPrivValTCP(t *testing.T) {
 	}()
 	defer signerServer.Stop() //nolint:errcheck // ignore for tests
 
-	n, err := DefaultNewNode(config, ipfs.Mock(), log.TestingLogger())
+	logger := log.TestingLogger()
+	n, err := DefaultNewNode(config, ipfs.Embedded(true, config.IPFS, logger), logger)
 	require.NoError(t, err)
 	assert.IsType(t, &privval.RetrySignerClient{}, n.PrivValidator())
 }
@@ -207,7 +208,8 @@ func TestNodeSetPrivValIPC(t *testing.T) {
 	}()
 	defer pvsc.Stop() //nolint:errcheck // ignore for tests
 
-	n, err := DefaultNewNode(config, ipfs.Mock(), log.TestingLogger())
+	logger := log.TestingLogger()
+	n, err := DefaultNewNode(config, ipfs.Embedded(true, config.IPFS, logger), logger)
 	require.NoError(t, err)
 	assert.IsType(t, &privval.RetrySignerClient{}, n.PrivValidator())
 }

--- a/test/e2e/app/main.go
+++ b/test/e2e/app/main.go
@@ -104,7 +104,7 @@ func startNode(cfg *Config) error {
 		proxy.NewLocalClientCreator(app),
 		node.DefaultGenesisDocProviderFunc(tmcfg),
 		node.DefaultDBProvider,
-		ipfs.Mock(), // TODO(Wondertan): Should we use real IPFS for E2E?
+		ipfs.Embedded(true, ipfs.DefaultConfig(), nodeLogger),
 		node.DefaultMetricsProvider(tmcfg.Instrumentation),
 		nodeLogger,
 	)

--- a/test/e2e/runner/load.go
+++ b/test/e2e/runner/load.go
@@ -25,7 +25,7 @@ func Load(ctx context.Context, testnet *e2e.Testnet) error {
 	if concurrency == 0 {
 		concurrency = 1
 	}
-	initialTimeout := 1 * time.Minute
+	initialTimeout := 5 * time.Minute
 	stallTimeout := 30 * time.Second
 
 	chTx := make(chan types.Tx)


### PR DESCRIPTION
So I went through every field in IPFS config and set what suits FullNode the best with documentation for every single field. We should also create a setup for LightNode and configuration for it accordingly

NOTE: The PR also sets Badger as default datastore