### PR TITLE
crypto/merkle: hashing ~10% faster and ~60% fewer allocs

### DIFF
--- a/crypto/merkle/hash.go
+++ b/crypto/merkle/hash.go
@@ -1,6 +1,8 @@
 package merkle
 
 import (
+	"hash"
+
 	"github.com/lazyledger/lazyledger-core/crypto/tmhash"
 )
 
@@ -20,7 +22,23 @@ func leafHash(leaf []byte) []byte {
 	return tmhash.Sum(append(leafPrefix, leaf...))
 }
 
+// returns tmhash(0x00 || leaf)
+func leafHashOpt(s hash.Hash, leaf []byte) []byte {
+	s.Reset()
+	s.Write(leafPrefix)
+	s.Write(leaf)
+	return s.Sum(nil)
+}
+
 // returns tmhash(0x01 || left || right)
 func innerHash(left []byte, right []byte) []byte {
 	return tmhash.Sum(append(innerPrefix, append(left, right...)...))
+}
+
+func innerHashOpt(s hash.Hash, left []byte, right []byte) []byte {
+	s.Reset()
+	s.Write(innerPrefix)
+	s.Write(left)
+	s.Write(right)
+	return s.Sum(nil)
 }

--- a/crypto/merkle/proof.go
+++ b/crypto/merkle/proof.go
@@ -50,13 +50,13 @@ func ProofsFromByteSlices(items [][]byte) (rootHash []byte, proofs []*Proof) {
 // Verify that the Proof proves the root hash.
 // Check sp.Index/sp.Total manually if needed
 func (sp *Proof) Verify(rootHash []byte, leaf []byte) error {
-	leafHash := leafHash(leaf)
 	if sp.Total < 0 {
 		return errors.New("proof total must be positive")
 	}
 	if sp.Index < 0 {
 		return errors.New("proof index cannot be negative")
 	}
+	leafHash := leafHash(leaf)
 	if !bytes.Equal(sp.LeafHash, leafHash) {
 		return fmt.Errorf("invalid leaf hash: wanted %X got %X", leafHash, sp.LeafHash)
 	}

--- a/crypto/merkle/proof_key_path_test.go
+++ b/crypto/merkle/proof_key_path_test.go
@@ -35,6 +35,7 @@ func TestKeyPath(t *testing.T) {
 
 		res, err := KeyPathToKeys(path.String())
 		require.Nil(t, err)
+		require.Equal(t, len(keys), len(res))
 
 		for i, key := range keys {
 			require.Equal(t, key, res[i])

--- a/crypto/merkle/proof_test.go
+++ b/crypto/merkle/proof_test.go
@@ -171,7 +171,6 @@ func TestProofValidateBasic(t *testing.T) {
 	}
 }
 func TestVoteProtobuf(t *testing.T) {
-
 	_, proofs := ProofsFromByteSlices([][]byte{
 		[]byte("apple"),
 		[]byte("watermelon"),

--- a/crypto/merkle/tree.go
+++ b/crypto/merkle/tree.go
@@ -1,22 +1,27 @@
 package merkle
 
 import (
+	"crypto/sha256"
+	"hash"
 	"math/bits"
 )
 
 // HashFromByteSlices computes a Merkle tree where the leaves are the byte slice,
 // in the provided order. It follows RFC-6962.
 func HashFromByteSlices(items [][]byte) []byte {
+	return hashFromByteSlices(sha256.New(), items)
+}
+func hashFromByteSlices(sha hash.Hash, items [][]byte) []byte {
 	switch len(items) {
 	case 0:
 		return emptyHash()
 	case 1:
-		return leafHash(items[0])
+		return leafHashOpt(sha, items[0])
 	default:
 		k := getSplitPoint(int64(len(items)))
-		left := HashFromByteSlices(items[:k])
-		right := HashFromByteSlices(items[k:])
-		return innerHash(left, right)
+		left := hashFromByteSlices(sha, items[:k])
+		right := hashFromByteSlices(sha, items[k:])
+		return innerHashOpt(sha, left, right)
 	}
 }
 
@@ -60,10 +65,11 @@ func HashFromByteSlices(items [][]byte) []byte {
 // read, it might not be worthwhile to switch to a less intuitive
 // implementation for so little benefit.
 func HashFromByteSlicesIterative(input [][]byte) []byte {
+	sha := sha256.New()
 	items := make([][]byte, len(input))
 
 	for i, leaf := range input {
-		items[i] = leafHash(leaf)
+		items[i] = leafHashOpt(sha, leaf)
 	}
 
 	size := len(items)
@@ -78,7 +84,7 @@ func HashFromByteSlicesIterative(input [][]byte) []byte {
 			wp := 0 // write position
 			for rp < size {
 				if rp+1 < size {
-					items[wp] = innerHash(items[rp], items[rp+1])
+					items[wp] = innerHashOpt(sha, items[rp], items[rp+1])
 					rp += 2
 				} else {
 					items[wp] = items[rp]

--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,6 @@ require (
 	github.com/lazyledger/rsmt2d v0.2.0
 	github.com/libp2p/go-buffer-pool v0.0.2
 	github.com/minio/highwayhash v1.0.1
-	github.com/minio/sha256-simd v0.1.1
 	github.com/multiformats/go-multiaddr v0.3.1
 	github.com/multiformats/go-multihash v0.0.14
 	github.com/petermattis/goid v0.0.0-20180202154549-b0b1615b78e5 // indirect

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/lazyledger/rsmt2d v0.2.0
 	github.com/libp2p/go-buffer-pool v0.0.2
 	github.com/minio/highwayhash v1.0.1
+	github.com/minio/sha256-simd v0.1.1
 	github.com/multiformats/go-multiaddr v0.3.1
 	github.com/multiformats/go-multihash v0.0.14
 	github.com/petermattis/goid v0.0.0-20180202154549-b0b1615b78e5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -613,8 +613,6 @@ github.com/lazyledger/go-verifcid v0.0.1-lazypatch h1:jAVwUw+DhuCzx5IcYpFh6d6HWx
 github.com/lazyledger/go-verifcid v0.0.1-lazypatch/go.mod h1:kXPYu0XqTNUKWA1h3M95UHjUqBzDwXVVt/RXZDjKJmQ=
 github.com/lazyledger/merkletree v0.0.0-20201214195110-6901c4c3c75f h1:jbyPAH6o6hGte4RtZBaqWs2n4Fl6hS7qJGXX3qnjiy4=
 github.com/lazyledger/merkletree v0.0.0-20201214195110-6901c4c3c75f/go.mod h1:10PA0NlnYtB8HrtwIDQAyTKWp8TEZ0zBZCGlYC/7+QE=
-github.com/lazyledger/nmt v0.4.0 h1:RcNmU7nfRtgsmIBN2T+5eOSfuOGLkX3F+cINdWdphrQ=
-github.com/lazyledger/nmt v0.4.0/go.mod h1:tY7ypPX26Sbkt6F8EbPl3AT33B5N0BJe4OVPbq849YI=
 github.com/lazyledger/nmt v0.5.0 h1:WEcFOx6rqJuI8wviyMgFH/ZOFL0jQowewxiHtErtV/I=
 github.com/lazyledger/nmt v0.5.0/go.mod h1:tY7ypPX26Sbkt6F8EbPl3AT33B5N0BJe4OVPbq849YI=
 github.com/lazyledger/rsmt2d v0.2.0 h1:RrKkAd9WTewCnOmAtvM5bz05PC+XzIYSrD+3V3odPtg=


### PR DESCRIPTION
This PR makes some optimizations that produce the following results compared to the `master` implementation:
```
name                          old time/op    new time/op    delta
HashAlternatives/recursive-8    72.2µs ± 6%    65.0µs ± 1%   -9.94%  (p=0.000 n=10+10)
HashAlternatives/iterative-8    71.5µs ± 1%    65.6µs ± 1%   -8.26%  (p=0.000 n=8+8)

name                          old alloc/op   new alloc/op   delta
HashAlternatives/recursive-8    25.4kB ± 0%     6.5kB ± 0%  -74.45%  (p=0.000 n=10+10)
HashAlternatives/iterative-8    28.1kB ± 0%     9.2kB ± 0%  -67.33%  (p=0.000 n=10+10)

name                          old allocs/op  new allocs/op  delta
HashAlternatives/recursive-8       497 ± 0%       200 ± 0%  -59.76%  (p=0.000 n=10+10)
HashAlternatives/iterative-8       498 ± 0%       201 ± 0%  -59.64%  (p=0.000 n=10+10)
```

The gist of the change is basically avoiding allocs, and some nit gain by using a SIMD sha256 implementation. The latter could also be considered for the `crypto/tmhash` package.

There's a further optimization possible that might reduce allocs even more with pooling, but the main bottleneck is sha256 calc as expected so maybe isn't worth it.

I kept the original `leftHash` and `innerHash` methods since they're used in other places, but looks to me can be removed and used the ones I introduced which will avoid the same kind in allocations in other places producing some performance gains in other packages.