### PR TITLE
ipld: Manual providing 

### DIFF
--- a/cmd/tendermint/commands/light.go
+++ b/cmd/tendermint/commands/light.go
@@ -184,6 +184,7 @@ func runProxy(cmd *cobra.Command, args []string) error {
 	case daSampling:
 		cfg := ipfs.DefaultConfig()
 		cfg.RootDir = dir
+		cfg.ServeAPI = true
 		// TODO(ismail): share badger instance
 		apiProvider := ipfs.Embedded(true, cfg, logger)
 		var dag coreiface.APIDagService

--- a/consensus/byzantine_test.go
+++ b/consensus/byzantine_test.go
@@ -16,6 +16,7 @@ import (
 	abcicli "github.com/lazyledger/lazyledger-core/abci/client"
 	abci "github.com/lazyledger/lazyledger-core/abci/types"
 	"github.com/lazyledger/lazyledger-core/evidence"
+	"github.com/lazyledger/lazyledger-core/ipfs"
 	"github.com/lazyledger/lazyledger-core/libs/db/memdb"
 	"github.com/lazyledger/lazyledger-core/libs/log"
 	"github.com/lazyledger/lazyledger-core/libs/service"
@@ -79,7 +80,8 @@ func TestByzantinePrevoteEquivocation(t *testing.T) {
 
 		// Make State
 		blockExec := sm.NewBlockExecutor(stateStore, log.TestingLogger(), proxyAppConnCon, mempool, evpool)
-		cs := NewState(thisConfig.Consensus, state, blockExec, blockStore, mempool, dag, evpool)
+		cs := NewState(thisConfig.Consensus, state, blockExec, blockStore,
+			mempool, dag, ipfs.MockRouting(), evpool)
 		cs.SetLogger(cs.Logger)
 		// set private validator
 		pv := privVals[i]

--- a/consensus/common_test.go
+++ b/consensus/common_test.go
@@ -24,6 +24,7 @@ import (
 	abci "github.com/lazyledger/lazyledger-core/abci/types"
 	cfg "github.com/lazyledger/lazyledger-core/config"
 	cstypes "github.com/lazyledger/lazyledger-core/consensus/types"
+	"github.com/lazyledger/lazyledger-core/ipfs"
 	tmbytes "github.com/lazyledger/lazyledger-core/libs/bytes"
 	dbm "github.com/lazyledger/lazyledger-core/libs/db"
 	"github.com/lazyledger/lazyledger-core/libs/db/memdb"
@@ -402,7 +403,7 @@ func newStateWithConfigAndBlockStore(
 	}
 
 	blockExec := sm.NewBlockExecutor(stateStore, log.TestingLogger(), proxyAppConnCon, mempool, evpool)
-	cs := NewState(thisConfig.Consensus, state, blockExec, blockStore, mempool, dag, evpool)
+	cs := NewState(thisConfig.Consensus, state, blockExec, blockStore, mempool, dag, ipfs.MockRouting(), evpool)
 	cs.SetLogger(log.TestingLogger().With("module", "consensus"))
 	cs.SetPrivValidator(pv)
 

--- a/consensus/reactor_test.go
+++ b/consensus/reactor_test.go
@@ -23,6 +23,7 @@ import (
 	cstypes "github.com/lazyledger/lazyledger-core/consensus/types"
 	cryptoenc "github.com/lazyledger/lazyledger-core/crypto/encoding"
 	"github.com/lazyledger/lazyledger-core/crypto/tmhash"
+	"github.com/lazyledger/lazyledger-core/ipfs"
 	"github.com/lazyledger/lazyledger-core/libs/bits"
 	"github.com/lazyledger/lazyledger-core/libs/bytes"
 	"github.com/lazyledger/lazyledger-core/libs/db/memdb"
@@ -184,7 +185,8 @@ func TestReactorWithEvidence(t *testing.T) {
 
 		// Make State
 		blockExec := sm.NewBlockExecutor(stateStore, log.TestingLogger(), proxyAppConnCon, mempool, evpool)
-		cs := NewState(thisConfig.Consensus, state, blockExec, blockStore, mempool, dag, evpool2)
+		cs := NewState(thisConfig.Consensus, state, blockExec, blockStore,
+			mempool, dag, ipfs.MockRouting(), evpool2)
 		cs.SetLogger(log.TestingLogger().With("module", "consensus"))
 		cs.SetPrivValidator(pv)
 

--- a/consensus/replay_file.go
+++ b/consensus/replay_file.go
@@ -12,6 +12,7 @@ import (
 
 	mdutils "github.com/ipfs/go-merkledag/test"
 	cfg "github.com/lazyledger/lazyledger-core/config"
+	"github.com/lazyledger/lazyledger-core/ipfs"
 	"github.com/lazyledger/lazyledger-core/libs/db/badgerdb"
 	"github.com/lazyledger/lazyledger-core/libs/log"
 	tmos "github.com/lazyledger/lazyledger-core/libs/os"
@@ -130,7 +131,7 @@ func (pb *playback) replayReset(count int, newStepSub types.Subscription) error 
 	pb.cs.Wait()
 
 	newCS := NewState(pb.cs.config, pb.genesisState.Copy(), pb.cs.blockExec,
-		pb.cs.blockStore, pb.cs.txNotifier, mdutils.Mock(), pb.cs.evpool)
+		pb.cs.blockStore, pb.cs.txNotifier, mdutils.Mock(), ipfs.MockRouting(), pb.cs.evpool)
 	newCS.SetEventBus(pb.cs.eventBus)
 	newCS.startForReplay()
 
@@ -331,8 +332,7 @@ func newConsensusStateForReplay(config cfg.BaseConfig, csConfig *cfg.ConsensusCo
 	blockExec := sm.NewBlockExecutor(stateStore, log.TestingLogger(), proxyApp.Consensus(), mempool, evpool)
 
 	consensusState := NewState(csConfig, state.Copy(), blockExec,
-		blockStore, mempool, dag, evpool)
-
+		blockStore, mempool, dag, ipfs.MockRouting(), evpool)
 	consensusState.SetEventBus(eventBus)
 	return consensusState
 }

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -1125,7 +1125,7 @@ func (cs *State) defaultDecideProposal(height int64, round int32) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*5)
 	defer cancel()
 	cs.Logger.Info("Putting Block to ipfs", "height", block.Height)
-	err = ipld.PutBlock(ctx, cs.dag, block, cs.croute)
+	err = ipld.PutBlock(ctx, cs.dag, block, cs.croute, cs.Logger, false)
 	if err != nil {
 		// If PutBlock fails we will be the only node that has the data
 		// this means something is seriously wrong and we can not recover

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -1122,10 +1122,11 @@ func (cs *State) defaultDecideProposal(height int64, round int32) {
 	// TODO(evan): don't hard code context and timeout
 	//
 	// longer timeouts result in block proposers failing to propose blocks in time
-	// TODO(Wondertan): rework context for cancel to be callable
-	ctx, _ := context.WithTimeout(context.Background(), time.Minute*5)
 	cs.Logger.Info("Putting Block to ipfs", "height", block.Height)
-	err = ipld.PutBlock(ctx, cs.dag, block, cs.croute, cs.Logger, false)
+	// TODO(Wondertan): CONTEXT !!!
+	//  We can't pass there cancelable context right now
+	//  Ideally, we should create context once proposing and it keep it alive until it is next turn to propose
+	err = ipld.PutBlock(context.TODO(), cs.dag, block, cs.croute, cs.Logger, false)
 	if err != nil {
 		// If PutBlock fails we will be the only node that has the data
 		// this means something is seriously wrong and we can not recover

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -1126,9 +1126,9 @@ func (cs *State) defaultDecideProposal(height int64, round int32) {
 		cs.proposalCancel()
 	}
 	cs.proposalCtx, cs.proposalCancel = context.WithCancel(context.TODO())
-	go func() {
+	go func(ctx context.Context) {
 		cs.Logger.Info("Putting Block to IPFS", "height", block.Height)
-		err = ipld.PutBlock(cs.proposalCtx, cs.dag, block, cs.croute, cs.Logger)
+		err = ipld.PutBlock(ctx, cs.dag, block, cs.croute, cs.Logger)
 		if err != nil {
 			if errors.Is(err, context.Canceled) {
 				cs.Logger.Error("Putting Block didn't finish in time and was terminated", "height", block.Height)
@@ -1138,7 +1138,7 @@ func (cs *State) defaultDecideProposal(height int64, round int32) {
 			return
 		}
 		cs.Logger.Info("Finished putting block to IPFS", "height", block.Height)
-	}()
+	}(cs.proposalCtx)
 }
 
 // Returns true if the proposal block is complete &&

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -1121,9 +1121,9 @@ func (cs *State) defaultDecideProposal(height int64, round int32) {
 	// post data to ipfs
 	// TODO(evan): don't hard code context and timeout
 	//
-	// longer timeouts result in block proposers failing to propose blocks in time.
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*5)
-	defer cancel()
+	// longer timeouts result in block proposers failing to propose blocks in time
+	// TODO(Wondertan): rework context for cancel to be callable
+	ctx, _ := context.WithTimeout(context.Background(), time.Minute*5)
 	cs.Logger.Info("Putting Block to ipfs", "height", block.Height)
 	err = ipld.PutBlock(ctx, cs.dag, block, cs.croute, cs.Logger, false)
 	if err != nil {

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -1122,7 +1122,7 @@ func (cs *State) defaultDecideProposal(height int64, round int32) {
 	// TODO(evan): don't hard code context and timeout
 	//
 	// longer timeouts result in block proposers failing to propose blocks in time.
-	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*1500)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*5)
 	defer cancel()
 	cs.Logger.Info("Putting Block to ipfs", "height", block.Height)
 	err = ipld.PutBlock(ctx, cs.dag, block, cs.croute)

--- a/consensus/wal_test.go
+++ b/consensus/wal_test.go
@@ -8,26 +8,25 @@ import (
 	"io"
 	mrand "math/rand"
 	"path/filepath"
-
-	// "sync"
 	"testing"
 	"time"
 
 	mdutils "github.com/ipfs/go-merkledag/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/lazyledger/lazyledger-core/abci/example/kvstore"
 	cfg "github.com/lazyledger/lazyledger-core/config"
+	"github.com/lazyledger/lazyledger-core/consensus/types"
+	"github.com/lazyledger/lazyledger-core/crypto/merkle"
+	"github.com/lazyledger/lazyledger-core/ipfs"
+	"github.com/lazyledger/lazyledger-core/libs/autofile"
 	"github.com/lazyledger/lazyledger-core/libs/db/memdb"
+	"github.com/lazyledger/lazyledger-core/libs/log"
 	"github.com/lazyledger/lazyledger-core/privval"
 	"github.com/lazyledger/lazyledger-core/proxy"
 	sm "github.com/lazyledger/lazyledger-core/state"
 	"github.com/lazyledger/lazyledger-core/store"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
-	"github.com/lazyledger/lazyledger-core/consensus/types"
-	"github.com/lazyledger/lazyledger-core/crypto/merkle"
-	"github.com/lazyledger/lazyledger-core/libs/autofile"
-	"github.com/lazyledger/lazyledger-core/libs/log"
 	tmtypes "github.com/lazyledger/lazyledger-core/types"
 	tmtime "github.com/lazyledger/lazyledger-core/types/time"
 )
@@ -339,7 +338,8 @@ func walGenerateNBlocks(t *testing.T, wr io.Writer, numBlocks int) (err error) {
 	evpool := sm.EmptyEvidencePool{}
 	blockExec := sm.NewBlockExecutor(stateStore, log.TestingLogger(), proxyApp.Consensus(), mempool, evpool)
 	require.NoError(t, err)
-	consensusState := NewState(config.Consensus, state.Copy(), blockExec, blockStore, mempool, dag, evpool)
+	consensusState := NewState(config.Consensus, state.Copy(), blockExec, blockStore,
+		mempool, dag, ipfs.MockRouting(), evpool)
 	consensusState.SetLogger(logger)
 	consensusState.SetEventBus(eventBus)
 	if privValidator != nil && privValidator != (*privval.FilePV)(nil) {

--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	github.com/libp2p/go-libp2p v0.12.0 // indirect
 	github.com/libp2p/go-libp2p-core v0.7.0 // indirect
 	github.com/libp2p/go-libp2p-kad-dht v0.11.1 // indirect
+	github.com/libp2p/go-libp2p-kbucket v0.4.7 // indirect
 	github.com/minio/highwayhash v1.0.1
 	github.com/multiformats/go-multiaddr v0.3.1
 	github.com/multiformats/go-multihash v0.0.14

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/ipfs/go-ipfs-api v0.2.0
 	github.com/ipfs/go-ipfs-blockstore v0.1.4 // indirect
 	github.com/ipfs/go-ipfs-config v0.11.0
+	github.com/ipfs/go-ipfs-routing v0.1.0 // indirect
 	github.com/ipfs/go-ipld-format v0.2.0
 	github.com/ipfs/go-merkledag v0.3.2
 	github.com/ipfs/go-path v0.0.9 // indirect
@@ -35,6 +36,7 @@ require (
 	github.com/lazyledger/rsmt2d v0.2.0
 	github.com/libp2p/go-buffer-pool v0.0.2
 	github.com/libp2p/go-libp2p v0.12.0 // indirect
+	github.com/libp2p/go-libp2p-core v0.7.0 // indirect
 	github.com/libp2p/go-libp2p-kad-dht v0.11.1 // indirect
 	github.com/minio/highwayhash v1.0.1
 	github.com/multiformats/go-multiaddr v0.3.1

--- a/go.mod
+++ b/go.mod
@@ -17,10 +17,14 @@ require (
 	github.com/gorilla/websocket v1.4.2
 	github.com/gtank/merlin v0.1.1
 	github.com/hdevalence/ed25519consensus v0.0.0-20201207055737-7fde80a9d5ff
+	github.com/ipfs/go-bitswap v0.3.3 // indirect
 	github.com/ipfs/go-block-format v0.0.2
+	github.com/ipfs/go-blockservice v0.1.4 // indirect
 	github.com/ipfs/go-cid v0.0.7
+	github.com/ipfs/go-datastore v0.4.5 // indirect
 	github.com/ipfs/go-ipfs v0.8.0
 	github.com/ipfs/go-ipfs-api v0.2.0
+	github.com/ipfs/go-ipfs-blockstore v0.1.4 // indirect
 	github.com/ipfs/go-ipfs-config v0.11.0
 	github.com/ipfs/go-ipld-format v0.2.0
 	github.com/ipfs/go-merkledag v0.3.2
@@ -30,6 +34,8 @@ require (
 	github.com/lazyledger/nmt v0.5.0
 	github.com/lazyledger/rsmt2d v0.2.0
 	github.com/libp2p/go-buffer-pool v0.0.2
+	github.com/libp2p/go-libp2p v0.12.0 // indirect
+	github.com/libp2p/go-libp2p-kad-dht v0.11.1 // indirect
 	github.com/minio/highwayhash v1.0.1
 	github.com/multiformats/go-multiaddr v0.3.1
 	github.com/multiformats/go-multihash v0.0.14

--- a/ipfs/defaults.go
+++ b/ipfs/defaults.go
@@ -125,9 +125,15 @@ func DefaultFullNodeConfig() (*ipfscfg.Config, error) {
 		// In kDHT all records have TTL, thus we have to regularly(Interval) reprovide/reannounce stored CID to the
 		// network. Otherwise information that the node stores something will be lost. Should be in tact with kDHT
 		// record cleaning configuration
+		// TODO(Wondertan) In case StrategicProviding is true, we have to implement reproviding manually.
 		Reprovider: ipfscfg.Reprovider{
 			Interval: "12h",
 			Strategy: "all",
+		},
+		// List of all experimental IPFS features
+		Experimental: ipfscfg.Experiments{
+			// Disables BitSwap providing and reproviding in favour of manual providing.
+			StrategicProviding: true,
 		},
 		Routing: ipfscfg.Routing{
 			// Full node must be available from the WAN thus 'dhtserver'
@@ -152,9 +158,6 @@ func DefaultFullNodeConfig() (*ipfscfg.Config, error) {
 		// Unused fields:
 		// we currently don't use PubSub
 		Pubsub: ipfscfg.PubsubConfig{},
-		// List of all experimental IPFS features
-		// We currently don't use any of them
-		Experimental: ipfscfg.Experiments{},
 		// bi-directional agreement between peers to hold connections with
 		Peering: ipfscfg.Peering{},
 		// local network discovery is useful, but there is no practical reason to have two FullNode in one LAN

--- a/ipfs/embedded.go
+++ b/ipfs/embedded.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"sync"
 
@@ -26,7 +25,7 @@ import (
 // Embedded is the provider that embeds IPFS node within the same process.
 // It also returns closable for graceful node shutdown.
 func Embedded(init bool, cfg *Config, logger log.Logger) APIProvider {
-	return func() (coreiface.APIDagService, io.Closer, error) {
+	return func() (coreiface.APIDagService, *core.IpfsNode, error) {
 		path := cfg.Path()
 		defer os.Setenv(ipfscfg.EnvDir, path)
 

--- a/ipfs/mock.go
+++ b/ipfs/mock.go
@@ -1,20 +1,49 @@
 package ipfs
 
 import (
-	"io"
+	"context"
 
+	nilrouting "github.com/ipfs/go-ipfs-routing/none"
+	"github.com/ipfs/go-ipfs/core"
+	coremock "github.com/ipfs/go-ipfs/core/mock"
 	ipld "github.com/ipfs/go-ipld-format"
-	mdutils "github.com/ipfs/go-merkledag/test"
 	coreiface "github.com/ipfs/interface-go-ipfs-core"
+	"github.com/libp2p/go-libp2p-core/routing"
+	mocknet "github.com/libp2p/go-libp2p/p2p/net/mock"
+
+	"github.com/lazyledger/lazyledger-core/ipfs/plugin"
 )
 
 // Mock provides simple mock IPFS API useful for testing
 func Mock() APIProvider {
-	return func() (coreiface.APIDagService, io.Closer, error) {
-		dom := dagOnlyMock{mdutils.Mock()}
+	return func() (coreiface.APIDagService, *core.IpfsNode, error) {
+		plugin.EnableNMT()
 
-		return dom, dom, nil
+		nd, err := MockNode()
+		if err != nil {
+			return nil, nil, err
+		}
+
+		return dagOnlyMock{nd.DAG}, nd, nil
 	}
+}
+
+func MockNode() (*core.IpfsNode, error) {
+	ctx := context.TODO()
+	nd, err := core.NewNode(ctx, &core.BuildCfg{
+		Online: true,
+		Host:   coremock.MockHostOption(mocknet.New(ctx)),
+	})
+	if err != nil {
+		return nil, err
+	}
+	nd.Routing = MockRouting()
+	return nd, err
+}
+
+func MockRouting() routing.Routing {
+	croute, _ := nilrouting.ConstructNilRouting(context.TODO(), nil, nil, nil)
+	return croute
 }
 
 type dagOnlyMock struct {

--- a/ipfs/mock.go
+++ b/ipfs/mock.go
@@ -51,5 +51,4 @@ type dagOnlyMock struct {
 }
 
 func (dom dagOnlyMock) Dag() coreiface.APIDagService { return dom }
-func (dagOnlyMock) Close() error                     { return nil }
 func (dom dagOnlyMock) Pinning() ipld.NodeAdder      { return dom }

--- a/ipfs/provider.go
+++ b/ipfs/provider.go
@@ -1,10 +1,9 @@
 package ipfs
 
 import (
-	"io"
-
+	"github.com/ipfs/go-ipfs/core"
 	coreiface "github.com/ipfs/interface-go-ipfs-core"
 )
 
 // APIProvider allows customizable IPFS core APIs.
-type APIProvider func() (coreiface.APIDagService, io.Closer, error)
+type APIProvider func() (coreiface.APIDagService, *core.IpfsNode, error)

--- a/p2p/ipld/net_test.go
+++ b/p2p/ipld/net_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/lazyledger/lazyledger-core/ipfs/plugin"
+	"github.com/lazyledger/lazyledger-core/libs/log"
 	"github.com/lazyledger/lazyledger-core/types"
 	"github.com/lazyledger/lazyledger-core/types/consts"
 )
@@ -50,6 +51,7 @@ func TestDiscovery(t *testing.T) {
 }
 
 func TestWriteDiscoveryReadData(t *testing.T) {
+	logger := log.TestingLogger()
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*3)
 	defer cancel()
 
@@ -64,7 +66,7 @@ func TestWriteDiscoveryReadData(t *testing.T) {
 		b.Hash()
 		blocks[i] = b
 
-		err := PutBlock(ctx, dag, blocks[i], dhts[i])
+		err := PutBlock(ctx, dag, blocks[i], dhts[i], logger, true)
 		require.NoError(t, err)
 	}
 

--- a/p2p/ipld/net_test.go
+++ b/p2p/ipld/net_test.go
@@ -66,7 +66,7 @@ func TestWriteDiscoveryReadData(t *testing.T) {
 		b.Hash()
 		blocks[i] = b
 
-		err := PutBlock(ctx, dag, blocks[i], dhts[i], logger, true)
+		err := PutBlock(ctx, dag, blocks[i], dhts[i], logger)
 		require.NoError(t, err)
 	}
 

--- a/p2p/ipld/net_test.go
+++ b/p2p/ipld/net_test.go
@@ -52,7 +52,7 @@ func TestDiscovery(t *testing.T) {
 
 func TestWriteDiscoveryReadData(t *testing.T) {
 	logger := log.TestingLogger()
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*3)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 	defer cancel()
 
 	dags, dhts := dagNet(ctx, t, 5)

--- a/p2p/ipld/net_test.go
+++ b/p2p/ipld/net_test.go
@@ -1,0 +1,134 @@
+package ipld
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ipfs/go-bitswap"
+	"github.com/ipfs/go-bitswap/network"
+	"github.com/ipfs/go-blockservice"
+	ds "github.com/ipfs/go-datastore"
+	dssync "github.com/ipfs/go-datastore/sync"
+	blockstore "github.com/ipfs/go-ipfs-blockstore"
+	ipld "github.com/ipfs/go-ipld-format"
+	"github.com/ipfs/go-merkledag"
+	"github.com/lazyledger/rsmt2d"
+	dht "github.com/libp2p/go-libp2p-kad-dht"
+	mocknet "github.com/libp2p/go-libp2p/p2p/net/mock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/lazyledger/lazyledger-core/ipfs/plugin"
+	"github.com/lazyledger/lazyledger-core/types"
+	"github.com/lazyledger/lazyledger-core/types/consts"
+)
+
+func TestDiscovery(t *testing.T)  {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	dhts := dhtNet(t, ctx, 2)
+	dht1, dht2 := dhts[0], dhts[0]
+
+	data := generateRandomBlockData(64, consts.MsgShareSize-2)
+	b := &types.Block{
+		Data:       data,
+		LastCommit: &types.Commit{},
+	}
+	b.Hash()
+
+	id, err := plugin.CidFromNamespacedSha256(b.DataAvailabilityHeader.RowsRoots[0].Bytes())
+	require.NoError(t, err)
+
+	err = dht1.Provide(ctx, id, false)
+	require.NoError(t, err)
+
+	prvs, err := dht2.FindProviders(ctx, id)
+	require.NoError(t, err)
+	assert.Equal(t, dht1.PeerID(), prvs[0].ID, "peer not found")
+}
+
+func TestWriteDiscoveryReadData(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*3)
+	defer cancel()
+
+	dags := dagNet(t, ctx, 5)
+	blocks := make([]*types.Block, len(dags))
+	for i, dag := range dags {
+		data := generateRandomBlockData(64, consts.MsgShareSize-2)
+		b := &types.Block{
+			Data:       data,
+			LastCommit: &types.Commit{},
+		}
+		b.Hash()
+		blocks[i] = b
+
+		err := PutBlock(ctx, dag, blocks[i])
+		require.NoError(t, err)
+	}
+
+	for i, dag := range dags {
+		if i == len(dags)-1 {
+			i = 0
+		}
+
+		exp := blocks[i+1]
+		actual, err := RetrieveBlockData(ctx, &exp.DataAvailabilityHeader, dag, rsmt2d.NewRSGF8Codec())
+		assert.NoError(t, err)
+		assert.EqualValues(t, exp.Data.Txs, actual.Txs, "blocks are not equal")
+	}
+}
+
+func dagNet(t *testing.T, ctx context.Context, num int) []ipld.DAGService {
+	net := mocknet.New(ctx)
+	_, medium := dagNode(t, ctx, net)
+	dags, dhts := make([]ipld.DAGService, num), make([]*dht.IpfsDHT, num)
+	for i := range dags {
+		dags[i], dhts[i] = dagNode(t, ctx, net)
+	}
+	bootstrap(t, ctx, net, medium, dhts...)
+	return dags
+}
+
+func dhtNet(t *testing.T, ctx context.Context, num int) []*dht.IpfsDHT {
+	net := mocknet.New(ctx)
+	medium := dhtNode(t, ctx, net)
+	dhts := make([]*dht.IpfsDHT, num)
+	for i := range dhts {
+		dhts[i] = dhtNode(t, ctx, net)
+	}
+	bootstrap(t, ctx, net, medium, dhts...)
+	return dhts
+}
+
+func dagNode(t *testing.T, ctx context.Context, net mocknet.Mocknet) (ipld.DAGService, *dht.IpfsDHT) {
+	dstore := dssync.MutexWrap(ds.NewMapDatastore())
+	bstore := blockstore.NewBlockstore(dstore)
+	routing := dhtNode(t, ctx, net)
+	bs := bitswap.New(ctx, network.NewFromIpfsHost(routing.Host(), routing), bstore)
+	return merkledag.NewDAGService(blockservice.New(bstore, bs)), routing
+}
+
+func dhtNode(t *testing.T, ctx context.Context, net mocknet.Mocknet) *dht.IpfsDHT {
+	host, err := net.GenPeer()
+	require.NoError(t, err)
+	dstore := dssync.MutexWrap(ds.NewMapDatastore())
+	routing, err := dht.New(ctx, host, dht.Datastore(dstore), dht.Mode(dht.ModeServer), dht.BootstrapPeers())
+	require.NoError(t, err)
+	return routing
+}
+
+func bootstrap(t *testing.T, ctx context.Context,  net mocknet.Mocknet, bstrapper *dht.IpfsDHT, peers ...*dht.IpfsDHT) {
+	err := net.LinkAll()
+	require.NoError(t, err)
+	for _, p := range peers {
+		_, err := net.ConnectPeers(bstrapper.PeerID(), p.PeerID())
+		require.NoError(t, err)
+		err = bstrapper.Bootstrap(ctx)
+		require.NoError(t, err)
+	}
+	err = bstrapper.Bootstrap(ctx)
+	require.NoError(t, err)
+}
+

--- a/p2p/ipld/net_test.go
+++ b/p2p/ipld/net_test.go
@@ -108,7 +108,7 @@ func dagNode(ctx context.Context, t *testing.T, net mocknet.Mocknet) (ipld.DAGSe
 	dstore := dssync.MutexWrap(ds.NewMapDatastore())
 	bstore := blockstore.NewBlockstore(dstore)
 	routing := dhtNode(ctx, t, net)
-	bs := bitswap.New(ctx, network.NewFromIpfsHost(routing.Host(), routing), bstore)
+	bs := bitswap.New(ctx, network.NewFromIpfsHost(routing.Host(), routing), bstore, bitswap.ProvideEnabled(false))
 	return merkledag.NewDAGService(blockservice.New(bstore, bs)), routing
 }
 

--- a/p2p/ipld/read_test.go
+++ b/p2p/ipld/read_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/lazyledger/lazyledger-core/ipfs"
 	"github.com/lazyledger/lazyledger-core/ipfs/plugin"
+	"github.com/lazyledger/lazyledger-core/libs/log"
 	"github.com/lazyledger/lazyledger-core/p2p/ipld/wrapper"
 	"github.com/lazyledger/lazyledger-core/types"
 	"github.com/lazyledger/lazyledger-core/types/consts"
@@ -115,6 +116,7 @@ func TestBlockRecovery(t *testing.T) {
 }
 
 func TestRetrieveBlockData(t *testing.T) {
+	logger := log.TestingLogger()
 	type test struct {
 		name       string
 		squareSize int
@@ -149,7 +151,7 @@ func TestRetrieveBlockData(t *testing.T) {
 
 			// if an error is exected, don't put the block
 			if !tc.expectErr {
-				err := PutBlock(ctx, dag, block, croute)
+				err := PutBlock(ctx, dag, block, croute, logger, true)
 				require.NoError(t, err)
 			}
 

--- a/p2p/ipld/read_test.go
+++ b/p2p/ipld/read_test.go
@@ -151,7 +151,7 @@ func TestRetrieveBlockData(t *testing.T) {
 
 			// if an error is exected, don't put the block
 			if !tc.expectErr {
-				err := PutBlock(ctx, dag, block, croute, logger, true)
+				err := PutBlock(ctx, dag, block, croute, logger)
 				require.NoError(t, err)
 			}
 

--- a/p2p/ipld/read_test.go
+++ b/p2p/ipld/read_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/lazyledger/lazyledger-core/ipfs"
 	"github.com/lazyledger/lazyledger-core/ipfs/plugin"
 	"github.com/lazyledger/lazyledger-core/p2p/ipld/wrapper"
 	"github.com/lazyledger/lazyledger-core/types"
@@ -138,6 +139,7 @@ func TestRetrieveBlockData(t *testing.T) {
 		t.Run(fmt.Sprintf("%s size %d", tc.name, tc.squareSize), func(t *testing.T) {
 			ctx := context.Background()
 			dag := mdutils.Mock()
+			croute := ipfs.MockRouting()
 
 			blockData := generateRandomBlockData(tc.squareSize*tc.squareSize, consts.MsgShareSize-2)
 			block := &types.Block{
@@ -147,7 +149,7 @@ func TestRetrieveBlockData(t *testing.T) {
 
 			// if an error is exected, don't put the block
 			if !tc.expectErr {
-				err := PutBlock(ctx, dag, block)
+				err := PutBlock(ctx, dag, block, croute)
 				require.NoError(t, err)
 			}
 

--- a/p2p/ipld/validate.go
+++ b/p2p/ipld/validate.go
@@ -15,7 +15,7 @@ import (
 // ValidationTimeout specifies timeout for DA validation during which data have to be found on the network,
 // otherwise ErrValidationFailed is thrown.
 // TODO: github.com/lazyledger/lazyledger-core/issues/280
-const ValidationTimeout = 1 * time.Minute
+const ValidationTimeout = 10 * time.Minute
 
 // ErrValidationFailed is returned whenever DA validation fails
 var ErrValidationFailed = errors.New("validation failed")

--- a/p2p/ipld/validate_test.go
+++ b/p2p/ipld/validate_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/lazyledger/lazyledger-core/ipfs"
 	"github.com/lazyledger/lazyledger-core/types"
 	"github.com/lazyledger/lazyledger-core/types/consts"
 )
@@ -34,7 +35,8 @@ func TestValidateAvailability(t *testing.T) {
 	block.Hash()
 
 	dag := mdutils.Mock()
-	err := PutBlock(ctx, dag, block)
+	croute := ipfs.MockRouting()
+	err := PutBlock(ctx, dag, block, croute)
 	require.NoError(t, err)
 
 	calls := 0

--- a/p2p/ipld/validate_test.go
+++ b/p2p/ipld/validate_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/lazyledger/lazyledger-core/ipfs"
+	"github.com/lazyledger/lazyledger-core/libs/log"
 	"github.com/lazyledger/lazyledger-core/types"
 	"github.com/lazyledger/lazyledger-core/types/consts"
 )
@@ -35,8 +36,7 @@ func TestValidateAvailability(t *testing.T) {
 	block.Hash()
 
 	dag := mdutils.Mock()
-	croute := ipfs.MockRouting()
-	err := PutBlock(ctx, dag, block, croute)
+	err := PutBlock(ctx, dag, block, ipfs.MockRouting(), log.TestingLogger(), true)
 	require.NoError(t, err)
 
 	calls := 0

--- a/p2p/ipld/validate_test.go
+++ b/p2p/ipld/validate_test.go
@@ -36,7 +36,7 @@ func TestValidateAvailability(t *testing.T) {
 	block.Hash()
 
 	dag := mdutils.Mock()
-	err := PutBlock(ctx, dag, block, ipfs.MockRouting(), log.TestingLogger(), true)
+	err := PutBlock(ctx, dag, block, ipfs.MockRouting(), log.TestingLogger())
 	require.NoError(t, err)
 
 	calls := 0

--- a/p2p/ipld/write.go
+++ b/p2p/ipld/write.go
@@ -83,9 +83,9 @@ type provider struct {
 	jobs  chan cid.Cid
 	total int32
 
-	croute routing.ContentRouting
-	log    log.Logger
-	took   time.Time
+	croute    routing.ContentRouting
+	log       log.Logger
+	startTime time.Time
 }
 
 func newProvider(ctx context.Context, croute routing.ContentRouting, toProvide int32, logger log.Logger) *provider {
@@ -101,7 +101,7 @@ func newProvider(ctx context.Context, croute routing.ContentRouting, toProvide i
 		go p.worker()
 	}
 	logger.Info("Started Providing to DHT")
-	p.took = time.Now()
+	p.startTime = time.Now()
 	return p
 }
 
@@ -158,7 +158,7 @@ func (p *provider) worker() {
 
 func (p *provider) provided() {
 	if atomic.AddInt32(&p.total, -1) == 0 {
-		p.log.Info("Finished providing to DHT", "took", time.Since(p.took).String())
+		p.log.Info("Finished providing to DHT", "took", time.Since(p.startTime).String())
 		close(p.done)
 	}
 }

--- a/p2p/ipld/write.go
+++ b/p2p/ipld/write.go
@@ -30,7 +30,6 @@ func PutBlock(
 	block *types.Block,
 	croute routing.ContentRouting,
 	logger log.Logger,
-	sync bool,
 ) error {
 	// recompute the shares
 	namespacedShares, _ := block.Data.ComputeShares()
@@ -68,9 +67,7 @@ func PutBlock(
 		return err
 	}
 	// wait until we provided all the roots if requested
-	if sync {
-		<-prov.Done()
-	}
+	<-prov.Done()
 	return prov.Err()
 }
 

--- a/p2p/ipld/write.go
+++ b/p2p/ipld/write.go
@@ -55,7 +55,7 @@ func PutBlock(
 	}
 	// get row and col roots to be provided
 	// this also triggers adding data to DAG
-	prov := newProvider(ctx, croute, logger.With("block", block.Hash().String()))
+	prov := newProvider(ctx, croute, logger.With("height", block.Height))
 	for _, root := range eds.RowRoots() {
 		prov.Provide(plugin.MustCidFromNamespacedSha256(root))
 	}

--- a/p2p/ipld/write.go
+++ b/p2p/ipld/write.go
@@ -2,25 +2,24 @@ package ipld
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"math"
+	"sync/atomic"
 
+	"github.com/ipfs/go-cid"
 	ipld "github.com/ipfs/go-ipld-format"
 	"github.com/lazyledger/nmt"
 	"github.com/lazyledger/rsmt2d"
+	"github.com/libp2p/go-libp2p-core/routing"
 
+	"github.com/lazyledger/lazyledger-core/ipfs/plugin"
 	"github.com/lazyledger/lazyledger-core/p2p/ipld/wrapper"
 	"github.com/lazyledger/lazyledger-core/types"
 )
 
 // PutBlock posts and pins erasured block data to IPFS using the provided
 // ipld.NodeAdder. Note: the erasured data is currently recomputed
-func PutBlock(ctx context.Context, adder ipld.NodeAdder, block *types.Block) error {
-	if adder == nil {
-		return errors.New("no ipfs node adder provided")
-	}
-
+func PutBlock(ctx context.Context, adder ipld.NodeAdder, block *types.Block, croute routing.ContentRouting) error {
 	// recompute the shares
 	namespacedShares, _ := block.Data.ComputeShares()
 	shares := namespacedShares.RawShares()
@@ -42,12 +41,85 @@ func PutBlock(ctx context.Context, adder ipld.NodeAdder, block *types.Block) err
 	if err != nil {
 		return fmt.Errorf("failure to recompute the extended data square: %w", err)
 	}
+	// get row and col roots to be provided
+	// this also triggers adding data to DAG
+	prov := newProvider(ctx, croute)
+	for _, root := range eds.RowRoots() {
+		prov.Provide(plugin.MustCidFromNamespacedSha256(root))
+	}
+	for _, root := range eds.ColumnRoots() {
+		prov.Provide(plugin.MustCidFromNamespacedSha256(root))
+	}
+	// wait until we provided all the roots
+	select {
+	case err = <-prov.Done():
+		if err != nil {
+			return err
+		}
+		// commit the batch to ipfs
+		return batchAdder.Commit()
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
 
-	// thanks to the batchAdder.Visit func we added to the nmt wrapper,
-	// generating the roots will start adding the data to IPFS
-	eds.RowRoots()
-	eds.ColumnRoots()
+var provideWorkers = 32
 
-	// commit the batch to ipfs
-	return batchAdder.Commit()
+type provider struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+	done   chan error
+	jobs   chan cid.Cid
+	total  int32
+	croute routing.ContentRouting
+}
+
+func newProvider(ctx context.Context, croute routing.ContentRouting) *provider {
+	ctx, cancel := context.WithCancel(ctx)
+	p := &provider{
+		ctx:    ctx,
+		cancel: cancel,
+		done:   make(chan error, 1),
+		jobs:   make(chan cid.Cid, provideWorkers),
+		croute: croute,
+	}
+	for range make([]bool, provideWorkers) {
+		go p.worker()
+	}
+	return p
+}
+
+func (p *provider) Provide(id cid.Cid) {
+	atomic.AddInt32(&p.total, 1)
+	select {
+	case p.jobs <- id:
+	case <-p.ctx.Done():
+	}
+}
+
+func (p *provider) Done() <-chan error {
+	return p.done
+}
+
+func (p *provider) worker() {
+	for {
+		select {
+		case id := <-p.jobs:
+			err := p.croute.Provide(p.ctx, id, true)
+			if err != nil {
+				select {
+				case p.done <- err:
+				case <-p.ctx.Done():
+				}
+			}
+
+			if atomic.AddInt32(&p.total, -1) == 0 {
+				p.cancel()
+				close(p.done)
+				return
+			}
+		case <-p.ctx.Done():
+			return
+		}
+	}
 }

--- a/p2p/ipld/write.go
+++ b/p2p/ipld/write.go
@@ -88,7 +88,7 @@ type provider struct {
 
 	croute routing.ContentRouting
 	log    log.Logger
-	took time.Time
+	took   time.Time
 }
 
 func newProvider(ctx context.Context, croute routing.ContentRouting, logger log.Logger) *provider {

--- a/p2p/ipld/write.go
+++ b/p2p/ipld/write.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math"
 	"sync/atomic"
+	"time"
 
 	"github.com/ipfs/go-cid"
 	ipld "github.com/ipfs/go-ipld-format"
@@ -87,6 +88,7 @@ type provider struct {
 
 	croute routing.ContentRouting
 	log    log.Logger
+	took time.Time
 }
 
 func newProvider(ctx context.Context, croute routing.ContentRouting, logger log.Logger) *provider {
@@ -100,6 +102,8 @@ func newProvider(ctx context.Context, croute routing.ContentRouting, logger log.
 	for range make([]bool, provideWorkers) {
 		go p.worker()
 	}
+	logger.Info("Started Providing to DHT")
+	p.took = time.Now()
 	return p
 }
 
@@ -153,7 +157,7 @@ func (p *provider) worker() {
 
 func (p *provider) provided() {
 	if atomic.AddInt32(&p.total, -1) == 0 {
-		p.log.Debug("Finished providing to DHT")
+		p.log.Info("Finished providing to DHT", "took", time.Since(p.took).String())
 		close(p.done)
 	}
 }

--- a/p2p/ipld/write.go
+++ b/p2p/ipld/write.go
@@ -130,7 +130,9 @@ func (p *provider) worker() {
 		select {
 		case id := <-p.jobs:
 			err := p.croute.Provide(p.ctx, id, true)
-			if err != nil && err != kbucket.ErrLookupFailure { // Check for error to decrease test log spamming
+			// Omit ErrLookupFailure to decrease test log spamming as
+			// this simply indicates we haven't connected to other DHT nodes yet.
+			if err != nil && err != kbucket.ErrLookupFailure {
 				if p.Err() == nil {
 					p.errLk.Lock()
 					p.err = err

--- a/p2p/ipld/write_test.go
+++ b/p2p/ipld/write_test.go
@@ -6,14 +6,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ipfs/go-ipfs/core/coreapi"
-	coremock "github.com/ipfs/go-ipfs/core/mock"
+	mdutils "github.com/ipfs/go-merkledag/test"
 	"github.com/lazyledger/nmt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	abci "github.com/lazyledger/lazyledger-core/abci/types"
 	"github.com/lazyledger/lazyledger-core/crypto/tmhash"
+	"github.com/lazyledger/lazyledger-core/ipfs"
 	"github.com/lazyledger/lazyledger-core/ipfs/plugin"
 	tmproto "github.com/lazyledger/lazyledger-core/proto/tendermint/types"
 	"github.com/lazyledger/lazyledger-core/types"
@@ -21,15 +21,8 @@ import (
 )
 
 func TestPutBlock(t *testing.T) {
-	ipfsNode, err := coremock.NewMockNode()
-	if err != nil {
-		t.Error(err)
-	}
-
-	ipfsAPI, err := coreapi.NewCoreAPI(ipfsNode)
-	if err != nil {
-		t.Error(err)
-	}
+	dag := mdutils.Mock()
+	croute := ipfs.MockRouting()
 
 	maxOriginalSquareSize := consts.MaxSquareSize / 2
 	maxShareCount := maxOriginalSquareSize * maxOriginalSquareSize
@@ -52,7 +45,7 @@ func TestPutBlock(t *testing.T) {
 		block := &types.Block{Data: tc.blockData}
 
 		t.Run(tc.name, func(t *testing.T) {
-			err = PutBlock(ctx, ipfsAPI.Dag(), block)
+			err := PutBlock(ctx, dag, block, croute)
 			if tc.expectErr {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tc.errString)
@@ -73,7 +66,7 @@ func TestPutBlock(t *testing.T) {
 				}
 
 				// retrieve the data from IPFS
-				_, err = ipfsAPI.Dag().Get(timeoutCtx, cid)
+				_, err = dag.Get(timeoutCtx, cid)
 				if err != nil {
 					t.Errorf("Root not found: %s", cid.String())
 				}
@@ -114,15 +107,9 @@ func toMessageSlice(msgs [][]byte) []*tmproto.Message {
 }
 
 func TestDataAvailabilityHeaderRewriteBug(t *testing.T) {
-	ipfsNode, err := coremock.NewMockNode()
-	if err != nil {
-		t.Error(err)
-	}
+	dag := mdutils.Mock()
+	croute := ipfs.MockRouting()
 
-	ipfsAPI, err := coreapi.NewCoreAPI(ipfsNode)
-	if err != nil {
-		t.Error(err)
-	}
 	txs := types.Txs{}
 	l := len(txs)
 	bzs := make([][]byte, l)
@@ -158,7 +145,7 @@ func TestDataAvailabilityHeaderRewriteBug(t *testing.T) {
 	hash1 := block.DataAvailabilityHeader.Hash()
 
 	ctx := context.TODO()
-	err = PutBlock(ctx, ipfsAPI.Dag(), block)
+	err = PutBlock(ctx, dag, block, croute)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/p2p/ipld/write_test.go
+++ b/p2p/ipld/write_test.go
@@ -15,12 +15,14 @@ import (
 	"github.com/lazyledger/lazyledger-core/crypto/tmhash"
 	"github.com/lazyledger/lazyledger-core/ipfs"
 	"github.com/lazyledger/lazyledger-core/ipfs/plugin"
+	"github.com/lazyledger/lazyledger-core/libs/log"
 	tmproto "github.com/lazyledger/lazyledger-core/proto/tendermint/types"
 	"github.com/lazyledger/lazyledger-core/types"
 	"github.com/lazyledger/lazyledger-core/types/consts"
 )
 
 func TestPutBlock(t *testing.T) {
+	logger := log.TestingLogger()
 	dag := mdutils.Mock()
 	croute := ipfs.MockRouting()
 
@@ -45,7 +47,7 @@ func TestPutBlock(t *testing.T) {
 		block := &types.Block{Data: tc.blockData}
 
 		t.Run(tc.name, func(t *testing.T) {
-			err := PutBlock(ctx, dag, block, croute)
+			err := PutBlock(ctx, dag, block, croute, logger, true)
 			if tc.expectErr {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tc.errString)
@@ -107,6 +109,7 @@ func toMessageSlice(msgs [][]byte) []*tmproto.Message {
 }
 
 func TestDataAvailabilityHeaderRewriteBug(t *testing.T) {
+	logger := log.TestingLogger()
 	dag := mdutils.Mock()
 	croute := ipfs.MockRouting()
 
@@ -145,7 +148,7 @@ func TestDataAvailabilityHeaderRewriteBug(t *testing.T) {
 	hash1 := block.DataAvailabilityHeader.Hash()
 
 	ctx := context.TODO()
-	err = PutBlock(ctx, dag, block, croute)
+	err = PutBlock(ctx, dag, block, croute, logger, true)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/p2p/ipld/write_test.go
+++ b/p2p/ipld/write_test.go
@@ -47,7 +47,7 @@ func TestPutBlock(t *testing.T) {
 		block := &types.Block{Data: tc.blockData}
 
 		t.Run(tc.name, func(t *testing.T) {
-			err := PutBlock(ctx, dag, block, croute, logger, true)
+			err := PutBlock(ctx, dag, block, croute, logger)
 			if tc.expectErr {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tc.errString)
@@ -148,7 +148,7 @@ func TestDataAvailabilityHeaderRewriteBug(t *testing.T) {
 	hash1 := block.DataAvailabilityHeader.Hash()
 
 	ctx := context.TODO()
-	err = PutBlock(ctx, dag, block, croute, logger, true)
+	err = PutBlock(ctx, dag, block, croute, logger)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
> Note: those PR does not only manual providing but I chose the name for the biggest change. 

This PR: 
* Provides networking tests in IPLD. Probably closes #349, not sure if that's enough
* Makes light client serve IPFS API by default(should be changed later to be configurable)
* Disables Bitswap providing and [reproviding](https://github.com/lazyledger/lazyledger-core/issues/393).
* Extends PutBlock with logger and code to manually provide Row and Cols to DHT
* Introduces provider in p2p/ipld that handles point above. NOTE: We need to extract it into an independent singleton. We can do this along with https://github.com/lazyledger/lazyledger-core/issues/393, so the code for provider is not final.
* Starts using ContentRouting interface from libp2p in Node(gained from IpfsNode which is now returned instead of io.Closer in ipfs.APIProvider)
* Update Mock IPFS provider and sets nil content routing. That's needed for tests.
* Does tricks to make CI happy